### PR TITLE
Patch 1

### DIFF
--- a/src/gd_midiGrabber.cpp
+++ b/src/gd_midiGrabber.cpp
@@ -142,9 +142,11 @@ gdMidiGrabberChannel::gdMidiGrabberChannel(Channel *ch, bool midichannel)
 
 	enable->value(ch->midiIn);
 	enable->callback(cb_enable, (void*)this);
-	enableTunnel->value(ch->tunnelIn);
-	enableTunnel->callback(cb_enableTunnel, (void*)this);
-
+	if( midichannel ) {
+		enableTunnel->value(ch->tunnelIn);
+		enableTunnel->callback(cb_enableTunnel, (void*)this);
+	}
+	
 	gu_setFavicon(this);
 	show();
 }

--- a/src/gd_midiGrabber.cpp
+++ b/src/gd_midiGrabber.cpp
@@ -104,7 +104,7 @@ void gdMidiGrabber::__cb_close() {
 /* ------------------------------------------------------------------ */
 
 
-gdMidiGrabberChannel::gdMidiGrabberChannel(Channel *ch)
+gdMidiGrabberChannel::gdMidiGrabberChannel(Channel *ch, bool midichannel)
 	:	gdMidiGrabber(300, 206, "MIDI Input Setup"),
 		ch(ch)
 {
@@ -114,8 +114,14 @@ gdMidiGrabberChannel::gdMidiGrabberChannel(Channel *ch)
 
 	set_modal();
 
-	enable = new gCheck(8, 2, 120, 20, "enable MIDI input");
-	enableTunnel = new gCheck(8, 16, 120, 20, "enable MIDI tunnelling");
+	if( midichannel ) {
+		enable = new gCheck(8, 2, 120, 20, "enable MIDI input");
+		enableTunnel = new gCheck(8, 16, 120, 20, "enable MIDI tunnelling");
+	} else {
+		enable = new gCheck(8, 8, 120, 20, "enable MIDI input");
+		enableTunnel = NULL;
+	}
+	
 	new gLearner(8,  30, w()-16, "key press",   cb_learn, &ch->midiInKeyPress);
 	new gLearner(8,  54, w()-16, "key release", cb_learn, &ch->midiInKeyRel);
 	new gLearner(8,  78, w()-16, "key kill",    cb_learn, &ch->midiInKill);

--- a/src/gd_midiGrabber.h
+++ b/src/gd_midiGrabber.h
@@ -119,7 +119,7 @@ private:
 
 public:
 
-	gdMidiGrabberChannel(class Channel *ch);
+	gdMidiGrabberChannel(class Channel *ch, bool midichannel=false);
 };
 
 

--- a/src/ge_channel.cpp
+++ b/src/ge_channel.cpp
@@ -752,7 +752,7 @@ void gMidiChannel::__cb_openMenu()
 	}
 
 	if (strcmp(m->label(), "Setup MIDI input...") == 0) {
-		gu_openSubWindow(mainWin, new gdMidiGrabberChannel(ch), 0);
+		gu_openSubWindow(mainWin, new gdMidiGrabberChannel(ch, true), 0);
 		return;
 	}
 }

--- a/src/ge_pianoRoll.cpp
+++ b/src/ge_pianoRoll.cpp
@@ -165,7 +165,8 @@ gPianoRoll::gPianoRoll(int X, int Y, int W, class gdActionEditor *pParent)
 						ACTION_MIDI,
 						a1->frame,
 						&a2,
-						kernelMidi::getIValue(0x80, a1_note, a1_velo));
+						kernelMidi::getIValue(0x80, a1_note, a1_velo),
+						kernelMidi::getIValue(0x80, a1_note, 0x40));
 
 				/* next action note off found: add a new gPianoItem to piano roll */
 

--- a/src/recorder.cpp
+++ b/src/recorder.cpp
@@ -540,7 +540,7 @@ void chanHasActions(int index)
 /* ------------------------------------------------------------------ */
 
 
-int getNextAction(int chan, char type, int frame, action **out, uint32_t iValue) 
+int getNextAction(int chan, char type, int frame, action **out, uint32_t iValue, uint32_t iValue2) 
 {
 	sortActions();  // mandatory
 
@@ -554,7 +554,7 @@ int getNextAction(int chan, char type, int frame, action **out, uint32_t iValue)
 		for (unsigned j=0; j<global.at(i).size; j++) {
 			action *a = global.at(i).at(j);
 			if (a->chan == chan && (type & a->type) == a->type) {
-				if (iValue == 0 || (iValue != 0 && a->iValue == iValue)) {
+				if (iValue == 0 || a->iValue == iValue || (iValue2 != 0 && a->iValue == iValue2)) {
 					*out = global.at(i).at(j);
 					return 1;
 				}

--- a/src/recorder.h
+++ b/src/recorder.h
@@ -166,10 +166,11 @@ void shrink(int new_fpb);
 
 /* getNextAction
  * return the nearest action in chan 'chan' of type 'action' starting
- * from 'frame'. Action can be a bitmask. If iValue != -1 search for
- * next action with iValue == iValue: useful for MIDI key_release. */
+ * from 'frame'. Action can be a bitmask. If iValue != 0 search for
+ * next action with iValue == ivalue, if iValue2 != 0 search for 
+ * next action with iValue == iValue2: useful for MIDI key_release. */
 
-int getNextAction(int chan, char action, int frame, struct action **out, uint32_t iValue=0);
+int getNextAction(int chan, char action, int frame, struct action **out, uint32_t iValue=0, uint32_t iValue2=0);
 
 /* getAction
  * return a pointer to action in chan 'chan' of type 'action' at frame


### PR DESCRIPTION
Here are some updates to the monocasual/midi-tunnel variant fork which correct the problems I noted in the original Pull Request. Specifically it:

1. Corrects the situation where tunnelled midi events were not showing on the piano roll;
2. Sets the 'enable MIDI tunnelling' checkbox to only show for midi channels, not sample channels.