### PR TITLE
Compatibility with midi devices without note-off

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,9 @@ compile
 debian/*.log
 debian/autoreconf.after
 debian/autoreconf.before
+giada.config
+giada.creator
+giada.creator.user
+giada.files
+giada.includes
+

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -147,6 +147,7 @@ void Conf::setDefault()
 	rsmpQuality    = 0;
 
 	midiPortIn  = DEFAULT_MIDI_PORT_IN;
+	noNoteOff   = false;
 	midiPortOut = DEFAULT_MIDI_PORT_OUT;
 	midiSync    = MIDI_SYNC_NONE;
 	midiTCfps   = 25.0f;
@@ -231,6 +232,8 @@ int Conf::read()
 
 	midiPortIn = atoi(getValue("midiPortIn").c_str());
 	if (midiPortIn < -1) midiPortIn = DEFAULT_MIDI_PORT_IN;
+
+	noNoteOff = atoi(getValue("noNoteOff").c_str());
 
 	midiSync  = atoi(getValue("midiSync").c_str());
 	midiTCfps = atof(getValue("midiTCfps").c_str());
@@ -372,6 +375,7 @@ int Conf::write()
 	fprintf(fp, "midiSystem=%d\n",  midiSystem);
 	fprintf(fp, "midiPortOut=%d\n", midiPortOut);
 	fprintf(fp, "midiPortIn=%d\n",  midiPortIn);
+	fprintf(fp, "noNoteOff=%d\n",   noNoteOff);
 	fprintf(fp, "midiSync=%d\n",    midiSync);
 	fprintf(fp, "midiTCfps=%f\n",   midiTCfps);
 

--- a/src/conf.h
+++ b/src/conf.h
@@ -67,6 +67,7 @@ public:
 	int   midiSystem;
 	int   midiPortOut;
 	int   midiPortIn;
+	bool  noNoteOff;
 	int   midiSync;  // see const.h
 	float midiTCfps;
 

--- a/src/gd_config.cpp
+++ b/src/gd_config.cpp
@@ -521,10 +521,11 @@ gTabMidi::gTabMidi(int X, int Y, int W, int H)
 	: Fl_Group(X, Y, W, H, "MIDI")
 {
 	begin();
-	system  = new gChoice(x()+92, y()+9, 253, 20, "System");
-	portOut = new gChoice(x()+92, system->y()+system->h()+8, 253, 20, "Output port");
-	portIn  = new gChoice(x()+92, portOut->y()+portOut->h()+8, 253, 20, "Input port");
-	sync    = new gChoice(x()+92, portIn->y()+portIn->h()+8, 253, 20, "Sync");
+	system	  = new gChoice(x()+92, y()+9, 253, 20, "System");
+	portOut	  = new gChoice(x()+92, system->y()+system->h()+8, 253, 20, "Output port");
+	portIn	  = new gChoice(x()+92, portOut->y()+portOut->h()+8, 253, 20, "Input port");
+	noNoteOff = new gCheck (x()+92, portIn->y()+portIn->h()+8, 253, 20, "Device does not send NoteOff");
+	sync	  = new gChoice(x()+92, noNoteOff->y()+noNoteOff->h()+8, 253, 20, "Sync");
 	new gBox(x(), sync->y()+sync->h()+8, w(), h()-100, "Restart Giada for the changes to take effect.");
 	end();
 
@@ -535,6 +536,8 @@ gTabMidi::gTabMidi(int X, int Y, int W, int H)
 	fetchSystems();
 	fetchOutPorts();
 	fetchInPorts();
+
+	noNoteOff->value(G_Conf.noNoteOff);
 
 	sync->add("(disabled)");
 	sync->add("MIDI Clock (master)");
@@ -621,6 +624,8 @@ void gTabMidi::save()
 
 	G_Conf.midiPortOut = portOut->value()-1;   // -1 because midiPortOut=-1 is '(disabled)'
 	G_Conf.midiPortIn  = portIn->value()-1;    // -1 because midiPortIn=-1 is '(disabled)'
+
+	G_Conf.noNoteOff   = noNoteOff->value();
 
 	if      (sync->value() == 0)
 		G_Conf.midiSync = MIDI_SYNC_NONE;

--- a/src/gd_config.h
+++ b/src/gd_config.h
@@ -75,6 +75,7 @@ public:
 	class gChoice *system;
 	class gChoice *portOut;
 	class gChoice *portIn;
+	class gCheck  *noNoteOff;
 	class gChoice *sync;
 
 	gTabMidi(int x, int y, int w, int h);

--- a/src/kernelMidi.cpp
+++ b/src/kernelMidi.cpp
@@ -269,7 +269,11 @@ void callback(double t, std::vector<unsigned char> *msg, void *data)
 	uint32_t input = getIValue(msg->at(0), msg->at(1), msg->at(2));
 	uint32_t chan  = input & 0x0F000000;
 	uint32_t value = input & 0x0000FF00;
-	uint32_t pure  = input & 0xFFFF0000;   // input without 'value' byte
+	uint32_t pure  = 0x00;
+	if (!G_Conf.noNoteOff)
+		pure  = input & 0xFFFF0000;   // input without 'value' byte
+	else
+		pure  = input & 0xFFFFFF00;   // input with 'value' byte
 
 	gLog("[KM] MIDI received - 0x%X (chan %d)", input, chan >> 24);
 


### PR DESCRIPTION
To fix issue describe in:
https://github.com/monocasual/giada/issues/35

This patch is to be compatible with midi devices without note-off.
A general setting enables the user to chose if the device sends note-off or not.

If the device doesn't, midi grabber grabs the velocity in addition to the note.