### PR TITLE
Midi tunnel

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -237,6 +237,7 @@
 /* channel voices messages - controller (0xB0) is a special subset of
  * this family: it drives knobs, volume, faders and such. */
 
+#define MIDI_PROGRAM        0xC0 << 24
 #define MIDI_CONTROLLER     0xB0 << 24
 #define MIDI_NOTE_ON        0x90 << 24
 #define MIDI_NOTE_OFF       0x80 << 24

--- a/src/gd_midiGrabber.cpp
+++ b/src/gd_midiGrabber.cpp
@@ -115,8 +115,8 @@ gdMidiGrabberChannel::gdMidiGrabberChannel(Channel *ch, bool midichannel)
 	set_modal();
 
 	if( midichannel ) {
-		enable = new gCheck(8, 2, 120, 20, "enable MIDI input");
-		enableTunnel = new gCheck(8, 16, 120, 20, "enable MIDI tunnelling");
+		enable = new gCheck(8, 4, 120, 20, "enable MIDI input");
+		enableTunnel = new gCheck(8, 24, 120, 20, "enable MIDI tunnelling");
 	} else {
 		enable = new gCheck(8, 8, 120, 20, "enable MIDI input");
 		enableTunnel = NULL;

--- a/src/gd_midiGrabber.cpp
+++ b/src/gd_midiGrabber.cpp
@@ -105,7 +105,7 @@ void gdMidiGrabber::__cb_close() {
 
 
 gdMidiGrabberChannel::gdMidiGrabberChannel(Channel *ch, bool midichannel)
-	:	gdMidiGrabber(300, 206, "MIDI Input Setup"),
+	:	gdMidiGrabber(300, 220, "MIDI Input Setup"),
 		ch(ch)
 {
 	char title[64];
@@ -122,13 +122,14 @@ gdMidiGrabberChannel::gdMidiGrabberChannel(Channel *ch, bool midichannel)
 		enableTunnel = NULL;
 	}
 	
-	new gLearner(8,  30, w()-16, "key press",   cb_learn, &ch->midiInKeyPress);
-	new gLearner(8,  54, w()-16, "key release", cb_learn, &ch->midiInKeyRel);
-	new gLearner(8,  78, w()-16, "key kill",    cb_learn, &ch->midiInKill);
-	new gLearner(8, 102, w()-16, "mute",        cb_learn, &ch->midiInMute);
-	new gLearner(8, 126, w()-16, "solo",        cb_learn, &ch->midiInSolo);
-	new gLearner(8, 150, w()-16, "volume",      cb_learn, &ch->midiInVolume);
-	int yy = 178;
+	int y = enableTunnel->y() + 20;
+	new gLearner(8, y+0,   w()-16, "key press",   cb_learn, &ch->midiInKeyPress);
+	new gLearner(8, y+24,  w()-16, "key release", cb_learn, &ch->midiInKeyRel);
+	new gLearner(8, y+48,  w()-16, "key kill",    cb_learn, &ch->midiInKill);
+	new gLearner(8, y+72,  w()-16, "mute",        cb_learn, &ch->midiInMute);
+	new gLearner(8, y+96,  w()-16, "solo",        cb_learn, &ch->midiInSolo);
+	new gLearner(8, y+120, w()-16, "volume",      cb_learn, &ch->midiInVolume);
+	int yy = y+150;
 
 	if (ch->type == CHANNEL_SAMPLE) {
 		size(300, 254);

--- a/src/gd_midiOutputSetup.cpp
+++ b/src/gd_midiOutputSetup.cpp
@@ -52,7 +52,7 @@ gdMidiOutputSetup::gdMidiOutputSetup(MidiChannel *ch)
 	progChange     = new gValue(x()+100, h()-50, 20, 20, "Prog Change");
 	bankChange     = new gValue(x()+100, h()-25, 20, 20, "Bank Change");
 
-	save   = new gButton(w()-88, bankChange->y()+bankChange->h()+8, 80, 20, "Save");
+	save   = new gButton(w()-88, bankChange->y(), 80, 20, "Save");
 	cancel = new gButton(w()-88-save->w()-8, save->y(), 80, 20, "Cancel");
 	end();
 

--- a/src/gd_midiOutputSetup.cpp
+++ b/src/gd_midiOutputSetup.cpp
@@ -41,11 +41,16 @@ extern Conf	G_Conf;
 
 
 gdMidiOutputSetup::gdMidiOutputSetup(MidiChannel *ch)
-	: gWindow(300, 64, "Midi Output Setup"), ch(ch)
+	: gWindow(310, 80, "Midi Output Setup"), ch(ch)
 {
 	begin();
 	enableOut      = new gCheck(x()+8, y()+8, 150, 20, "Enable MIDI output");
 	chanListOut    = new gChoice(w()-108, y()+8, 100, 20);
+
+	enableProgChg  = new gCheck(x()+8, h()+2-50, 20, 20);
+	enableBankChg  = new gCheck(x()+8, h()+2-25, 20, 20);
+	progChange     = new gValue(x()+100, h()-50, 20, 20, "Prog Change");
+	bankChange     = new gValue(x()+100, h()-25, 20, 20, "Bank Change");
 
 	save   = new gButton(w()-88, chanListOut->y()+chanListOut->h()+8, 80, 20, "Save");
 	cancel = new gButton(w()-88-save->w()-8, save->y(), 80, 20, "Cancel");
@@ -53,14 +58,24 @@ gdMidiOutputSetup::gdMidiOutputSetup(MidiChannel *ch)
 
 	fillChanMenu(chanListOut);
 
-	if (ch->midiOut)
+	if (ch->midiOut) {
 		enableOut->value(1);
-	else
+		if( ch->midiOutProg ) enableProgChg->value(1);
+		if( ch->midiOutBank ) enableBankChg->value(1);
+	} else {
 		chanListOut->deactivate();
+		progChange->deactivate();
+		bankChange->deactivate();
+	}
 
 	chanListOut->value(ch->midiOutChan);
+	progChange->value(ch->midiProgChg);
+	bankChange->value(ch->midiBankChg);
 
 	enableOut->callback(cb_enableChanList, (void*)this);
+	enableProgChg->callback(cb_enableProgChg, (void*)this);
+	enableBankChg->callback(cb_enableBankChg, (void*)this);
+
 	save->callback(cb_save, (void*)this);
 	cancel->callback(cb_cancel, (void*)this);
 
@@ -76,6 +91,8 @@ gdMidiOutputSetup::gdMidiOutputSetup(MidiChannel *ch)
 void gdMidiOutputSetup::cb_save          (Fl_Widget *w, void *p) { ((gdMidiOutputSetup*)p)->__cb_save(); }
 void gdMidiOutputSetup::cb_cancel        (Fl_Widget *w, void *p) { ((gdMidiOutputSetup*)p)->__cb_cancel(); }
 void gdMidiOutputSetup::cb_enableChanList(Fl_Widget *w, void *p) { ((gdMidiOutputSetup*)p)->__cb_enableChanList(); }
+void gdMidiOutputSetup::cb_enableProgChg(Fl_Widget *w, void *p) { ((gdMidiOutputSetup*)p)->__cb_enableProgChg(); }
+void gdMidiOutputSetup::cb_enableBankChg(Fl_Widget *w, void *p) { ((gdMidiOutputSetup*)p)->__cb_enableBankChg(); }
 
 
 /* ------------------------------------------------------------------ */
@@ -89,9 +106,29 @@ void gdMidiOutputSetup::__cb_enableChanList() {
 /* ------------------------------------------------------------------ */
 
 
+void gdMidiOutputSetup::__cb_enableProgChg() {
+	enableProgChg->value() ? progChange->activate() : progChange->deactivate();
+}
+
+
+/* ------------------------------------------------------------------ */
+
+
+void gdMidiOutputSetup::__cb_enableBankChg() {
+	enableBankChg->value() ? bankChange->activate() : bankChange->deactivate();
+}
+
+
+/* ------------------------------------------------------------------ */
+
+
 void gdMidiOutputSetup::__cb_save() {
 	ch->midiOut     = enableOut->value();
 	ch->midiOutChan = chanListOut->value();
+	ch->midiOutProg = enableProgChg->value();
+	ch->midiOutBank = enableBankChg->value();
+	ch->midiProgChg = progChange->value();
+	ch->midiBankChg = bankChange->value();
 	ch->guiChannel->update();
 	do_callback();
 }

--- a/src/gd_midiOutputSetup.cpp
+++ b/src/gd_midiOutputSetup.cpp
@@ -52,7 +52,7 @@ gdMidiOutputSetup::gdMidiOutputSetup(MidiChannel *ch)
 	progChange     = new gValue(x()+100, h()-50, 20, 20, "Prog Change");
 	bankChange     = new gValue(x()+100, h()-25, 20, 20, "Bank Change");
 
-	save   = new gButton(w()-88, chanListOut->y()+chanListOut->h()+8, 80, 20, "Save");
+	save   = new gButton(w()-88, bankChange->y()+bankChange->h()+8, 80, 20, "Save");
 	cancel = new gButton(w()-88-save->w()-8, save->y(), 80, 20, "Cancel");
 	end();
 

--- a/src/gd_midiOutputSetup.h
+++ b/src/gd_midiOutputSetup.h
@@ -53,7 +53,10 @@ private:
 	void fillChanMenu(class gChoice *m);
 
 	class gCheck  *enableOut;
+	class gCheck  *enableProgChg, *enableBankChg;
 	class gChoice *chanListOut;
+	class gValue  *progChange, *bankChange;
+
 	class gButton *save;
 	class gButton *cancel;
 

--- a/src/gd_midiOutputSetup.h
+++ b/src/gd_midiOutputSetup.h
@@ -42,10 +42,14 @@ private:
 	static void cb_save          (Fl_Widget *w, void *p);
 	static void cb_cancel        (Fl_Widget *w, void *p);
 	static void cb_enableChanList(Fl_Widget *w, void *p);
+	static void cb_enableProgChg(Fl_Widget *w, void *p);
+	static void cb_enableBankChg(Fl_Widget *w, void *p);
 	inline void __cb_save          ();
 	inline void __cb_cancel        ();
 	inline void __cb_enableChanList();
-
+	inline void __cb_enableProgChg();
+	inline void __cb_enableBankChg();
+	
 	void fillChanMenu(class gChoice *m);
 
 	class gCheck  *enableOut;

--- a/src/ge_mixed.cpp
+++ b/src/ge_mixed.cpp
@@ -54,6 +54,23 @@ void __cb_window_closer(Fl_Widget *v, void *p)
 /* ------------------------------------------------------------------ */
 
 
+gValue::gValue(int x, int y, int w, int h, const char *L)
+: Fl_Value_Input(x, y, w, h, L)
+{
+  //Fl::set_boxtype(G_BOX, gDrawBox, 1, 1, 2, 2);
+  labelsize(11);
+  labelcolor(COLOR_TEXT_0);
+  color(COLOR_BG_DARK);
+  textcolor(COLOR_TEXT_0);
+  cursor_color(COLOR_TEXT_0);
+  selection_color(COLOR_BD_0);
+  textsize(11);
+}
+
+
+/* ------------------------------------------------------------------ */
+
+
 gButton::gButton(int X, int Y, int W, int H, const char *L, const char **imgOff, const char **imgOn)
   : gClick(X, Y, W, H, L, imgOff, imgOn) {}
 

--- a/src/ge_mixed.h
+++ b/src/ge_mixed.h
@@ -66,6 +66,17 @@ void __cb_window_closer(Fl_Widget *v, void *p);
 /* ------------------------------------------------------------------ */
 
 
+class gValue : public Fl_Value_Input
+{
+  public:
+	 gValue(int x, int y, int w, int h, const char *l=0);
+
+};
+
+
+/* ------------------------------------------------------------------ */
+
+
 class gBaseButton : public Fl_Button
 {
 private:

--- a/src/ge_mixed.h
+++ b/src/ge_mixed.h
@@ -51,6 +51,7 @@
 #include <FL/Fl_Int_Input.H>
 #include <FL/Fl_Choice.H>
 #include <FL/Fl_Scroll.H>
+#include <FL/Fl_Value_Input.H>
 
 #ifdef _WIN32
 	#include <shlobj.h>  // for SHGetFolderPath

--- a/src/midiChannel.cpp
+++ b/src/midiChannel.cpp
@@ -180,9 +180,9 @@ void MidiChannel::onZero(int frame) {
 void MidiChannel::setMute(bool internal) {
 	mute = true;  	// internal mute does not exist for midi (for now)
 	if (midiOut)
-		kernelMidi::send(MIDI_ALL_NOTES_OFF);
+		kernelMidi::send((uint32_t) MIDI_CHANS[midiOutChan] | MIDI_ALL_NOTES_OFF);
 #ifdef WITH_VST
-		addVstMidiEvent(MIDI_ALL_NOTES_OFF);
+		addVstMidiEvent((uint32_t) MIDI_CHANS[midiOutChan] | MIDI_ALL_NOTES_OFF);
 #endif
 }
 
@@ -248,9 +248,9 @@ void MidiChannel::stopBySeq() {
 void MidiChannel::kill(int frame) {
 	if (status & (STATUS_PLAY | STATUS_ENDING)) {
 		if (midiOut)
-			kernelMidi::send(MIDI_ALL_NOTES_OFF);
+			kernelMidi::send((uint32_t) MIDI_CHANS[midiOutChan] | MIDI_ALL_NOTES_OFF);
 #ifdef WITH_VST
-		addVstMidiEvent(MIDI_ALL_NOTES_OFF);
+		addVstMidiEvent((uint32_t) MIDI_CHANS[midiOutChan] | MIDI_ALL_NOTES_OFF);
 #endif
 	}
 	status = STATUS_OFF;
@@ -327,9 +327,9 @@ void MidiChannel::recvMidi(uint32_t data)
 
 void MidiChannel::rewind() {
 	if (midiOut)
-		kernelMidi::send(MIDI_ALL_NOTES_OFF);
+		kernelMidi::send((uint32_t) MIDI_CHANS[midiOutChan] | MIDI_ALL_NOTES_OFF);
 #ifdef WITH_VST
-		addVstMidiEvent(MIDI_ALL_NOTES_OFF);
+		addVstMidiEvent((uint32_t) MIDI_CHANS[midiOutChan] | MIDI_ALL_NOTES_OFF);
 #endif
 }
 

--- a/src/midiChannel.h
+++ b/src/midiChannel.h
@@ -55,9 +55,9 @@ public:
 	~MidiChannel();
 
   bool    midiOut;           // enable midi output
+  uint8_t midiOutChan;       // midi output channel
   bool    midiOutProg;       // enable program change
   bool    midiOutBank;       // enable bank change
-  uint8_t midiOutChan;       // midi output channel
   uint8_t midiProgChg;       // program change value
   uint8_t midiBankChg;       // bank change value
 

--- a/src/midiChannel.h
+++ b/src/midiChannel.h
@@ -55,7 +55,11 @@ public:
 	~MidiChannel();
 
   bool    midiOut;           // enable midi output
+  bool    midiOutProg;       // enable program change
+  bool    midiOutBank;       // enable bank change
   uint8_t midiOutChan;       // midi output channel
+  uint8_t midiProgChg;       // program change value
+  uint8_t midiBankChg;       // bank change value
 
 	void  process    (float *buffer);
 	void  start      (int frame, bool doQuantize);


### PR DESCRIPTION
These changes add the ability to send midi program change and bank select messages on a per channel basis, for midi channels. They are sent when the channel goes into play mode by clicking the activate button. These functions are controlled on the midi output dialog box.

Also fixed with this update is the widget crowding issue on the midi input dialog box. Both midi dialog boxes have been enlarged. Also fixed was a long-standing issue where midi ALL_NOTES_OFF messages where not getting sent out correctly, and appeared to be having no useful effect; they were appearing as note-off for C with a velocity of -1.