### PR TITLE
fixed src/gui/elems/config/tabPlugins.cpp relative paths

### DIFF
--- a/src/gui/elems/config/tabPlugins.cpp
+++ b/src/gui/elems/config/tabPlugins.cpp
@@ -29,11 +29,11 @@
 
 
 #include <FL/Fl.H>
-#include "../../core/const.h"
-#include "../../core/conf.h"
-#include "../../core/pluginHost.h"
-#include "../../utils/string.h"
-#include "../../utils/fs.h"
+#include "../../../core/const.h"
+#include "../../../core/conf.h"
+#include "../../../core/pluginHost.h"
+#include "../../../utils/string.h"
+#include "../../../utils/fs.h"
 #include "../basics/box.h"
 #include "../basics/radio.h"
 #include "../basics/check.h"


### PR DESCRIPTION
See #132 . `tabPlugins.cpp` was looking to levels up (`../../`) for includes in `src/core` and `src/utils`; other files in this directory point three levels up (`../../../`).