### PR TITLE
Solo lightning fixed + playing_inaudible lightning event

### DIFF
--- a/src/core/channel.cpp
+++ b/src/core/channel.cpp
@@ -202,14 +202,17 @@ void Channel::sendMidiLstatus()
 		case ChannelStatus::OFF:
 			kernelMidi::sendMidiLightning(midiOutLplaying, midimap::stopped);
 			break;
-		case ChannelStatus::PLAY:
-			kernelMidi::sendMidiLightning(midiOutLplaying, midimap::playing);
-			break;
 		case ChannelStatus::WAIT:
 			kernelMidi::sendMidiLightning(midiOutLplaying, midimap::waiting);
 			break;
 		case ChannelStatus::ENDING:
 			kernelMidi::sendMidiLightning(midiOutLplaying, midimap::stopping);
+			break;
+		case ChannelStatus::PLAY:
+			if (giada::m::mixer::isChannelAudible(this) && !(this->mute))
+				kernelMidi::sendMidiLightning(midiOutLplaying, midimap::playing);
+			else
+				kernelMidi::sendMidiLightning(midiOutLplaying, midimap::playing_inaudible);
 			break;
 		default:
 			break;

--- a/src/core/channel.cpp
+++ b/src/core/channel.cpp
@@ -209,7 +209,8 @@ void Channel::sendMidiLstatus()
 			kernelMidi::sendMidiLightning(midiOutLplaying, midimap::stopping);
 			break;
 		case ChannelStatus::PLAY:
-			if (giada::m::mixer::isChannelAudible(this) && !(this->mute))
+			if ((giada::m::mixer::isChannelAudible(this) && !(this->mute)) ||
+					!isDefined(midimap::playing_inaudible))
 				kernelMidi::sendMidiLightning(midiOutLplaying, midimap::playing);
 			else
 				kernelMidi::sendMidiLightning(midiOutLplaying, midimap::playing_inaudible);

--- a/src/core/channel.h
+++ b/src/core/channel.h
@@ -88,10 +88,15 @@ public:
 
 	virtual void kill(int localFrame) = 0;
 
-	/* set
+	/* set mute
 	What to do when channel is un/muted. */
 
 	virtual void setMute(bool value) = 0;
+
+	/* set solo
+	What to do when channel is un/soloed. */
+
+	virtual void setSolo(bool value) = 0;
 
 	/* empty
 	Frees any associated resources (e.g. waveform for SAMPLE). */

--- a/src/core/const.h
+++ b/src/core/const.h
@@ -460,18 +460,19 @@ const int MIDI_CHANS[G_MAX_MIDI_CHANS] = {
 
 /* JSON midimaps keys */
 
-#define MIDIMAP_KEY_BRAND          "brand"
-#define MIDIMAP_KEY_DEVICE         "device"
-#define MIDIMAP_KEY_INIT_COMMANDS  "init_commands"
-#define MIDIMAP_KEY_MUTE_ON        "mute_on"
-#define MIDIMAP_KEY_MUTE_OFF       "mute_off"
-#define MIDIMAP_KEY_SOLO_ON        "solo_on"
-#define MIDIMAP_KEY_SOLO_OFF       "solo_off"
-#define MIDIMAP_KEY_WAITING        "waiting"
-#define MIDIMAP_KEY_PLAYING        "playing"
-#define MIDIMAP_KEY_STOPPING       "stopping"
-#define MIDIMAP_KEY_STOPPED        "stopped"
-#define MIDIMAP_KEY_CHANNEL        "channel"
-#define MIDIMAP_KEY_MESSAGE        "message"
+#define MIDIMAP_KEY_BRAND                   "brand"
+#define MIDIMAP_KEY_DEVICE                  "device"
+#define MIDIMAP_KEY_INIT_COMMANDS           "init_commands"
+#define MIDIMAP_KEY_MUTE_ON                 "mute_on"
+#define MIDIMAP_KEY_MUTE_OFF                "mute_off"
+#define MIDIMAP_KEY_SOLO_ON                 "solo_on"
+#define MIDIMAP_KEY_SOLO_OFF                "solo_off"
+#define MIDIMAP_KEY_WAITING                 "waiting"
+#define MIDIMAP_KEY_PLAYING                 "playing"
+#define MIDIMAP_KEY_PLAYING_INAUDIBLE       "playing_inaudible"
+#define MIDIMAP_KEY_STOPPING                "stopping"
+#define MIDIMAP_KEY_STOPPED                 "stopped"
+#define MIDIMAP_KEY_CHANNEL                 "channel"
+#define MIDIMAP_KEY_MESSAGE                 "message"
 
 #endif

--- a/src/core/kernelMidi.cpp
+++ b/src/core/kernelMidi.cpp
@@ -258,6 +258,14 @@ void send(int b1, int b2, int b3)
 
 void sendMidiLightning(uint32_t learn, const midimap::message_t& msg)
 {
+	// Skip lightning message if not defined in midi map
+
+	if (!midimap::isDefined(msg))
+	{
+		gu_log("[KM] message skipped (not defined in midimap)");
+		return;
+	}
+
 	gu_log("[KM] learn=%#X, chan=%d, msg=%#X, offset=%d\n", learn, msg.channel, 
 		msg.value, msg.offset);
 

--- a/src/core/midiChannel.cpp
+++ b/src/core/midiChannel.cpp
@@ -130,6 +130,15 @@ void MidiChannel::setMute(bool value)
 /* -------------------------------------------------------------------------- */
 
 
+void MidiChannel::setSolo(bool value)
+{
+	midiChannelProc::setSolo(this, value);
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+
 void MidiChannel::readPatch(const string& basePath, int i)
 {
 	Channel::readPatch("", i);

--- a/src/core/midiChannel.h
+++ b/src/core/midiChannel.h
@@ -56,6 +56,7 @@ public:
 	void stop() override {};
 	void rewindBySeq() override;
 	void setMute(bool value) override;
+	void setSolo(bool value) override;
 	void readPatch(const std::string& basePath, int i) override;
 	void writePatch(int i, bool isProject) override;
 	void receiveMidi(const giada::m::MidiEvent& midiEvent) override;

--- a/src/core/midiChannelProc.cpp
+++ b/src/core/midiChannelProc.cpp
@@ -3,7 +3,7 @@
 #include "kernelMidi.h"
 #include "const.h"
 #include "midiChannelProc.h"
-
+#include "mixerHandler.h"
 
 namespace giada {
 namespace m {
@@ -149,7 +149,26 @@ void setMute(MidiChannel* ch, bool v)
 			ch->addVstMidiEvent(MIDI_ALL_NOTES_OFF, 0);
 	#endif		
 		}
+
+	for (Channel* channel : giada::m::mixer::channels)		// This is for processing playing_inaudible
+		channel->sendMidiLstatus();
+
 	ch->sendMidiLmute();
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+
+void setSolo(MidiChannel* ch, bool v)
+{
+	ch->solo = v;
+	m::mh::updateSoloCount();
+
+	for (Channel* channel : giada::m::mixer::channels)		// This is for processing playing_inaudible
+		channel->sendMidiLstatus();
+
+	ch->sendMidiLsolo();
 }
 
 

--- a/src/core/midiChannelProc.h
+++ b/src/core/midiChannelProc.h
@@ -46,6 +46,7 @@ void rewindBySeq(MidiChannel* ch);
 Mutes/unmutes a channel. */
 
 void setMute(MidiChannel* ch, bool v);
+void setSolo(MidiChannel* ch, bool v);
 }}};
 
 

--- a/src/core/midiMapConf.cpp
+++ b/src/core/midiMapConf.cpp
@@ -57,7 +57,7 @@ bool readInitCommands(json_t *jContainer)
 	json_t *jInitCommand;
 	json_array_foreach(jInitCommands, commandIndex, jInitCommand) {
 
-		string indexStr = "init command " + gu_iToString(commandIndex);				// "init command " ?? WTF
+		string indexStr = "init command " + gu_iToString(commandIndex);
 		if (!storager::checkObject(jInitCommand, indexStr.c_str()))
 			return 0;
 
@@ -96,7 +96,11 @@ void parse(message_t *message)
 {
 	/* Remove '0x' part from the original string. */
 
-	string input = message->valueStr.replace(0, 2, "");
+	string input = message->valueStr;
+
+	size_t f = input.find("0x");					// check if "0x" is there
+	if (f!=std::string::npos)
+		input = message->valueStr.replace(f, 2, "");
 
 	/* Then transform string value into the actual uint32_t value, by parsing
 	 * each char (i.e. nibble) in the original string. Substitute 'n' with
@@ -232,6 +236,15 @@ void setDefault()
 /* -------------------------------------------------------------------------- */
 
 
+bool isDefined(message_t msg)
+{
+	return (msg.offset!=-1);
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+
 int read(const string &file)
 {
 	if (file.empty()) {
@@ -250,30 +263,17 @@ int read(const string &file)
   }
 
 	if (!storager::setString(jRoot, MIDIMAP_KEY_BRAND, brand))   return MIDIMAP_UNREADABLE;
-  if (!storager::setString(jRoot, MIDIMAP_KEY_DEVICE, device)) return MIDIMAP_UNREADABLE;
+    if (!storager::setString(jRoot, MIDIMAP_KEY_DEVICE, device)) return MIDIMAP_UNREADABLE;
 	if (!readInitCommands(jRoot)) return MIDIMAP_UNREADABLE;
-	if (!readCommand(jRoot, &muteOn,   MIDIMAP_KEY_MUTE_ON))  return MIDIMAP_UNREADABLE;
-	if (!readCommand(jRoot, &muteOff,  MIDIMAP_KEY_MUTE_OFF)) return MIDIMAP_UNREADABLE;
-	if (!readCommand(jRoot, &soloOn,   MIDIMAP_KEY_SOLO_ON))  return MIDIMAP_UNREADABLE;
-	if (!readCommand(jRoot, &soloOff,  MIDIMAP_KEY_SOLO_OFF)) return MIDIMAP_UNREADABLE;
-	if (!readCommand(jRoot, &waiting,  MIDIMAP_KEY_WAITING))  return MIDIMAP_UNREADABLE;
-	if (!readCommand(jRoot, &playing,  MIDIMAP_KEY_PLAYING))  return MIDIMAP_UNREADABLE;
-	if (!readCommand(jRoot, &stopping, MIDIMAP_KEY_STOPPING)) return MIDIMAP_UNREADABLE;
-	if (!readCommand(jRoot, &stopped,  MIDIMAP_KEY_STOPPED))  return MIDIMAP_UNREADABLE;
-	if (!readCommand(jRoot, &playing_inaudible,  MIDIMAP_KEY_PLAYING_INAUDIBLE))  return MIDIMAP_UNREADABLE;
-
-
-	/* parse messages */
-
-	parse(&muteOn);
-	parse(&muteOff);
-	parse(&soloOn);
-	parse(&soloOff);
-	parse(&waiting);
-	parse(&playing);
-	parse(&stopping);
-	parse(&stopped);
-	parse(&playing_inaudible);
+	if (readCommand(jRoot, &muteOn,   MIDIMAP_KEY_MUTE_ON))  parse(&muteOn);
+	if (readCommand(jRoot, &muteOff,  MIDIMAP_KEY_MUTE_OFF)) parse(&muteOff);
+	if (readCommand(jRoot, &soloOn,   MIDIMAP_KEY_SOLO_ON))  parse(&soloOn);
+	if (readCommand(jRoot, &soloOff,  MIDIMAP_KEY_SOLO_OFF)) parse(&soloOff);
+	if (readCommand(jRoot, &waiting,  MIDIMAP_KEY_WAITING))  parse(&waiting);
+	if (readCommand(jRoot, &playing,  MIDIMAP_KEY_PLAYING))  parse(&playing);
+	if (readCommand(jRoot, &stopping, MIDIMAP_KEY_STOPPING)) parse(&stopping);
+	if (readCommand(jRoot, &stopped,  MIDIMAP_KEY_STOPPED))  parse(&stopped);
+	if (readCommand(jRoot, &playing_inaudible,  MIDIMAP_KEY_PLAYING_INAUDIBLE))  parse(&playing_inaudible);
 
 	return MIDIMAP_READ_OK;
 }

--- a/src/core/midiMapConf.cpp
+++ b/src/core/midiMapConf.cpp
@@ -57,7 +57,7 @@ bool readInitCommands(json_t *jContainer)
 	json_t *jInitCommand;
 	json_array_foreach(jInitCommands, commandIndex, jInitCommand) {
 
-		string indexStr = "init command " + gu_iToString(commandIndex);
+		string indexStr = "init command " + gu_iToString(commandIndex);				// "init command " ?? WTF
 		if (!storager::checkObject(jInitCommand, indexStr.c_str()))
 			return 0;
 
@@ -141,6 +141,7 @@ message_t waiting;
 message_t playing;
 message_t stopping;
 message_t stopped;
+message_t playing_inaudible;
 
 string midimapsPath;
 vector<string> maps;
@@ -221,6 +222,10 @@ void setDefault()
 	stopped.valueStr  = "";
 	stopped.offset    = -1;
 	stopped.value     = 0;
+	playing_inaudible.channel   = 0;
+	playing_inaudible.valueStr  = "";
+	playing_inaudible.offset    = -1;
+	playing_inaudible.value     = 0;
 }
 
 
@@ -255,6 +260,8 @@ int read(const string &file)
 	if (!readCommand(jRoot, &playing,  MIDIMAP_KEY_PLAYING))  return MIDIMAP_UNREADABLE;
 	if (!readCommand(jRoot, &stopping, MIDIMAP_KEY_STOPPING)) return MIDIMAP_UNREADABLE;
 	if (!readCommand(jRoot, &stopped,  MIDIMAP_KEY_STOPPED))  return MIDIMAP_UNREADABLE;
+	if (!readCommand(jRoot, &playing_inaudible,  MIDIMAP_KEY_PLAYING_INAUDIBLE))  return MIDIMAP_UNREADABLE;
+
 
 	/* parse messages */
 
@@ -266,6 +273,7 @@ int read(const string &file)
 	parse(&playing);
 	parse(&stopping);
 	parse(&stopped);
+	parse(&playing_inaudible);
 
 	return MIDIMAP_READ_OK;
 }

--- a/src/core/midiMapConf.h
+++ b/src/core/midiMapConf.h
@@ -56,6 +56,7 @@ extern message_t waiting;
 extern message_t playing;
 extern message_t stopping;
 extern message_t stopped;
+extern message_t playing_inaudible;
 
 /* midimapsPath
  * path of midimap files, different between OSes. */
@@ -83,6 +84,6 @@ Read a midi map from file 'file'. */
 
 int read(const std::string &file);
 
-}}}; // giada::m::midimap::
+}}};
 
 #endif

--- a/src/core/midiMapConf.h
+++ b/src/core/midiMapConf.h
@@ -75,15 +75,20 @@ Parse the midi maps folders and find the available maps. */
 void init();
 
 /* setDefault
-Set default values in case no maps are available/choosen. */
+Set default values in case no maps are available/chosen. */
 
 void setDefault();
+
+/* isDefined
+Check whether a specific message has been defined within midi map file.*/
+
+bool isDefined(message_t msg);
 
 /* read
 Read a midi map from file 'file'. */
 
 int read(const std::string &file);
 
-}}};
+}}}; // giada::m::midimap::
 
 #endif

--- a/src/core/mixer.h
+++ b/src/core/mixer.h
@@ -96,7 +96,7 @@ Is mixer silent? */
 
 bool isSilent();
 
-bool isChannelAudible(Channel* ch);
+extern bool isChannelAudible(Channel* ch);
 
 /* rewind
 Rewinds sequencer to frame 0. */

--- a/src/core/mixer.h
+++ b/src/core/mixer.h
@@ -96,7 +96,7 @@ Is mixer silent? */
 
 bool isSilent();
 
-extern bool isChannelAudible(Channel* ch);
+bool isChannelAudible(Channel* ch);
 
 /* rewind
 Rewinds sequencer to frame 0. */

--- a/src/core/sampleChannel.cpp
+++ b/src/core/sampleChannel.cpp
@@ -223,6 +223,14 @@ void SampleChannel::setMute(bool value)
 /* -------------------------------------------------------------------------- */
 
 
+void SampleChannel::setSolo(bool value)
+{
+	sampleChannelProc::setSolo(this, value);
+}
+
+/* -------------------------------------------------------------------------- */
+
+
 void SampleChannel::process(giada::m::AudioBuffer& out, 
 	const giada::m::AudioBuffer& in, bool audible, bool running)
 {

--- a/src/core/sampleChannel.h
+++ b/src/core/sampleChannel.h
@@ -61,6 +61,7 @@ public:
 	bool recordKill() override;
 	void recordStop() override;
 	void setMute(bool value) override;
+	void setSolo(bool value) override;
 	void startReadingActions(bool treatRecsAsLoops, bool recsStopOnChanHalt) override;
 	void stopReadingActions(bool running, bool treatRecsAsLoops, 
 		bool recsStopOnChanHalt) override;

--- a/src/core/sampleChannelProc.cpp
+++ b/src/core/sampleChannelProc.cpp
@@ -362,7 +362,6 @@ void setMute(SampleChannel* ch, bool value)
 		channel->sendMidiLstatus();
 
 	ch->sendMidiLmute();
-	ch->sendMidiLsolo();
 }
 
 

--- a/src/core/sampleChannelProc.cpp
+++ b/src/core/sampleChannelProc.cpp
@@ -31,6 +31,7 @@
 #include "pluginHost.h"
 #include "sampleChannel.h"
 #include "sampleChannelProc.h"
+#include "mixerHandler.h"
 
 
 namespace giada {
@@ -356,7 +357,28 @@ void rewindBySeq(SampleChannel* ch)
 void setMute(SampleChannel* ch, bool value)
 {
 	ch->mute = value;
+
+	for (Channel* channel : giada::m::mixer::channels)		// This is for processing playing_inaudible
+		channel->sendMidiLstatus();
+
 	ch->sendMidiLmute();
+	ch->sendMidiLsolo();
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+
+void setSolo(SampleChannel* ch, bool value)
+{
+	ch->solo = value;
+	m::mh::updateSoloCount();
+
+	for (Channel* channel : giada::m::mixer::channels)		// This is for processing playing_inaudible
+		channel->sendMidiLstatus();
+
+	ch->sendMidiLsolo();
+
 }
 
 

--- a/src/core/sampleChannelProc.h
+++ b/src/core/sampleChannelProc.h
@@ -85,6 +85,7 @@ actions from Recorder. */
 void start(SampleChannel* ch, int localFrame, bool doQuantize, int velocity);
 
 void setMute(SampleChannel* ch, bool value);
+void setSolo(SampleChannel* ch, bool value);
 }}};
 
 

--- a/src/glue/channel.cpp
+++ b/src/glue/channel.cpp
@@ -285,8 +285,7 @@ void toggleMute(Channel* ch, bool gui)
 
 void toggleSolo(Channel* ch, bool gui)
 {
-	ch->solo = !ch->solo;
-	m::mh::updateSoloCount();	
+	ch->setSolo(!ch->solo);
 	if (!gui) {
 		Fl::lock();
 		ch->guiChannel->solo->value(ch->solo);


### PR DESCRIPTION
Sorry for not doing that in separate pull requests, I'm completely new to git.
So I fixed solo lightning (midi messages were not sent), some discussion happened in forum's bugs section.

I also introduced new lightning event, playing_inaudible, which enables alternative midi message for channels playing, but muted or soloed out.
I made all events in giadamap file optional (i.e. do nothing when not defined). I kept "brand" and "device" fields mandatory. I explicitly handled lack of "playing_inaudible" message definition - giada will use "playing" instead.

I hope you'll like my work!