### PR TITLE
Include missing atomic include

### DIFF
--- a/src/core/init.cpp
+++ b/src/core/init.cpp
@@ -27,6 +27,7 @@
 
 #include <thread>
 #include <ctime>
+#include <atomic>
 #ifdef __APPLE__
 	#include <pwd.h>
 #endif


### PR DESCRIPTION
`src/core/init.cpp` is missing an include for `atomic` leading to undefined type errors for `G_quit` on gcc 8.2.1 (and most likely much earlier already).
