### PR TITLE
feat() Adds toggle to enable linear dial controls

### DIFF
--- a/src/core/conf.cpp
+++ b/src/core/conf.cpp
@@ -202,6 +202,7 @@ bool read()
 	conf.midiInVolumeOut       =  j.value(CONF_KEY_MIDI_IN_VOLUME_OUT, conf.midiInVolumeOut);
 	conf.midiInBeatDouble      =  j.value(CONF_KEY_MIDI_IN_BEAT_DOUBLE, conf.midiInBeatDouble);
 	conf.midiInBeatHalf        =  j.value(CONF_KEY_MIDI_IN_BEAT_HALF, conf.midiInBeatHalf);
+	conf.linearDialControl     =  j.value(CONF_KEY_LINEAR_DIAL_CONTROL, conf.linearDialControl);
 #ifdef WITH_VST
 	conf.pluginChooserX        = j.value(CONF_KEY_PLUGIN_CHOOSER_X, conf.pluginChooserX);
 	conf.pluginChooserY        = j.value(CONF_KEY_PLUGIN_CHOOSER_Y, conf.pluginChooserY);
@@ -297,6 +298,7 @@ bool write()
 	j[CONF_KEY_MIDI_INPUT_H]              = conf.midiInputH;
 	j[CONF_KEY_REC_TRIGGER_MODE]          = static_cast<int>(conf.recTriggerMode);
 	j[CONF_KEY_REC_TRIGGER_LEVEL]         = conf.recTriggerLevel;
+	j[CONF_KEY_LINEAR_DIAL_CONTROL]       = conf.linearDialControl;
 #ifdef WITH_VST
 	j[CONF_KEY_PLUGIN_CHOOSER_X]          = conf.pluginChooserX;
 	j[CONF_KEY_PLUGIN_CHOOSER_Y]          = conf.pluginChooserY;

--- a/src/core/conf.h
+++ b/src/core/conf.h
@@ -127,6 +127,7 @@ struct Conf
 	uint32_t midiInBeatDouble = 0x0;
 	uint32_t midiInBeatHalf   = 0x0;
 
+	bool linearDialControl = false;
 #ifdef WITH_VST
 
 	int pluginChooserX; 

--- a/src/core/const.h
+++ b/src/core/const.h
@@ -455,6 +455,7 @@ constexpr auto CONF_KEY_MIDI_INPUT_H             = "midi_input_h";
 constexpr auto CONF_KEY_PLUGIN_SORT_METHOD       = "plugin_sort_method";
 constexpr auto CONF_KEY_REC_TRIGGER_MODE         = "rec_trigger_mode";
 constexpr auto CONF_KEY_REC_TRIGGER_LEVEL        = "rec_trigger_level";
+constexpr auto CONF_KEY_LINEAR_DIAL_CONTROL      = "linear_dial_control";
 
 /* JSON midimaps keys */
 

--- a/src/gui/elems/basics/dial.cpp
+++ b/src/gui/elems/basics/dial.cpp
@@ -26,9 +26,17 @@
 
 
 #include <FL/fl_draw.H>
+#include "../../../core/conf.h"
 #include "../../../core/const.h"
 #include "dial.h"
 
+// drag distance to map widget value range, 10% of screen height
+const int geDial::dragDistanceToMax = Fl::h() * 0.1f;
+
+namespace {
+constexpr float numberOfMouseWheelSteps = 30;
+constexpr float mouseWheelDelta = 1.0f / numberOfMouseWheelSteps;
+}
 
 geDial::geDial(int x, int y, int w, int h, const char *l)
 : Fl_Dial(x, y, w, h, l)
@@ -56,4 +64,47 @@ void geDial::draw()
   fl_color(G_COLOR_GREY_4);
   fl_arc(x(), y(), w(), h(), 0, 360);
   fl_pie(x(), y(), w(), h(), 270-angle, 270-angle1());
+}
+
+int geDial::handle(int event)
+{
+  if(giada::m::conf::conf.linearDialControl) {
+    switch(event) {
+      case FL_PUSH: {
+        if ( Fl::event_state(FL_BUTTON1) ) {
+          dragBeginY = Fl::event_y();
+          valueBeginDrag = value();
+        }
+        return 1;
+      }
+      case FL_DRAG: {
+        if ( Fl::event_state(FL_BUTTON1) ) {
+          if ( dragging == false ) { // catch the "click" event
+            dragging = true;
+          }
+
+          float deltaY = dragBeginY - Fl::event_y();
+          const auto newValue = std::min(1.0f, std::max(0.0f, valueBeginDrag + deltaY / dragDistanceToMax));
+
+          set_value( newValue );
+
+          redraw();
+          do_callback(); // makes FLTK call "extra" code entered in FLUID
+          return 1;
+        }
+      }
+      case FL_RELEASE: {
+        dragging = false;
+        return 1;
+      }
+      case FL_MOUSEWHEEL: {
+        const auto newValue = std::min(1.0, std::max(0.0, value() - Fl::event_dy() * mouseWheelDelta));
+        set_value( newValue );
+        redraw();
+        do_callback();
+        return 1;
+      }
+    }
+  }
+	return Fl_Dial::handle(event);
 }

--- a/src/gui/elems/basics/dial.h
+++ b/src/gui/elems/basics/dial.h
@@ -30,6 +30,7 @@
 
 
 #include <FL/Fl_Dial.H>
+#include <FL/Fl.H>
 
 
 class geDial : public Fl_Dial
@@ -39,6 +40,13 @@ public:
 	geDial(int x, int y, int w, int h, const char *l=0);
 
 	void draw();
+
+	int handle(int event);
+	protected:
+	bool dragging = false;
+	int dragBeginY = 0;
+	float valueBeginDrag = 0.0f;
+	static const int dragDistanceToMax;
 };
 
 

--- a/src/gui/elems/config/tabBehaviors.cpp
+++ b/src/gui/elems/config/tabBehaviors.cpp
@@ -56,6 +56,7 @@ geTabBehaviors::geTabBehaviors(int X, int Y, int W, int H)
 
 	treatRecsAsLoops      = new geCheck(x(), radioGrp_2->y()+radioGrp_2->h() + 15, 280, 20, "Treat one shot channels with actions as loops");
 	inputMonitorDefaultOn = new geCheck(x(), treatRecsAsLoops->y()+treatRecsAsLoops->h() + 5, 280, 20, "New sample channels have input monitor on by default");
+	linearDialControl     = new geCheck(x(), inputMonitorDefaultOn->y()+inputMonitorDefaultOn->h() + 5, 280, 20, "Linear dial controls (drag along Y axis)");
 
 	end();
 
@@ -66,6 +67,7 @@ geTabBehaviors::geTabBehaviors(int X, int Y, int W, int H)
 	m::conf::conf.chansStopOnSeqHalt == 1 ? chansStopOnSeqHalt_1->value(1) : chansStopOnSeqHalt_0->value(1);
 	treatRecsAsLoops->value(m::conf::conf.treatRecsAsLoops);
 	inputMonitorDefaultOn->value(m::conf::conf.inputMonitorDefaultOn);
+	linearDialControl->value(m::conf::conf.linearDialControl);
 
 	recsStopOnChanHalt_1->callback(cb_radio_mutex, (void*)this);
 	recsStopOnChanHalt_0->callback(cb_radio_mutex, (void*)this);
@@ -101,5 +103,6 @@ void geTabBehaviors::save()
 	m::conf::conf.chansStopOnSeqHalt = chansStopOnSeqHalt_1->value() == 1 ? 1 : 0;
 	m::conf::conf.treatRecsAsLoops = treatRecsAsLoops->value() == 1 ? 1 : 0;
 	m::conf::conf.inputMonitorDefaultOn = inputMonitorDefaultOn->value() == 1 ? 1 : 0;
+	m::conf::conf.linearDialControl = linearDialControl->value() == 1 ? true : false;
 }
 }} // giada::v::

--- a/src/gui/elems/config/tabBehaviors.h
+++ b/src/gui/elems/config/tabBehaviors.h
@@ -53,6 +53,7 @@ public:
 	geRadio *chansStopOnSeqHalt_0;
 	geCheck *treatRecsAsLoops;
 	geCheck *inputMonitorDefaultOn;
+	geCheck *linearDialControl;
 
 
 private:


### PR DESCRIPTION
Hi,

this PR adds linear dial control (instead of circular) and allows this to be configured. Furthermore, the linear mode also supports mousewheel input.
I've tested this with linux. Unfortunately, I couldn't test other platforms. 

Please let me know if there is anything missing.  

Regards,
Mathias