### PR TITLE
Modernize giada::u::log::print to handle std::string arguments

### DIFF
--- a/src/core/init.cpp
+++ b/src/core/init.cpp
@@ -206,11 +206,11 @@ void printBuildInfo_()
 	u::log::print("[init] Build date: " BUILD_DATE "\n");
 	u::log::print("[init] Dependencies:\n");
 	u::log::print("[init]   FLTK - %d.%d.%d\n", FL_MAJOR_VERSION, FL_MINOR_VERSION, FL_PATCH_VERSION);
-	u::log::print("[init]   RtAudio - %s\n", u::ver::getRtAudioVersion().c_str());
-	u::log::print("[init]   RtMidi - %s\n", u::ver::getRtMidiVersion().c_str());
+	u::log::print("[init]   RtAudio - %s\n", u::ver::getRtAudioVersion());
+	u::log::print("[init]   RtMidi - %s\n", u::ver::getRtMidiVersion());
 	u::log::print("[init]   Libsamplerate\n"); // TODO - print version
-	u::log::print("[init]   Libsndfile - %s\n", u::ver::getLibsndfileVersion().c_str());
-	u::log::print("[init]   JSON for modern C++ - %d.%d.%d\n", 
+	u::log::print("[init]   Libsndfile - %s\n", u::ver::getLibsndfileVersion());
+	u::log::print("[init]   JSON for modern C++ - %d.%d.%d\n",
 		NLOHMANN_JSON_VERSION_MAJOR, NLOHMANN_JSON_VERSION_MINOR, NLOHMANN_JSON_VERSION_PATCH);
 #ifdef WITH_VST
 	u::log::print("[init]   JUCE - %d.%d.%d\n", JUCE_MAJOR_VERSION, JUCE_MINOR_VERSION, JUCE_BUILDNUMBER);

--- a/src/core/kernelAudio.cpp
+++ b/src/core/kernelAudio.cpp
@@ -151,7 +151,7 @@ int openDevice()
 	else {
 		u::log::print("[KA] %d device(s) found\n", numDevs);
 		for (unsigned i=0; i<numDevs; i++)
-			u::log::print("  %d) %s\n", i, getDeviceName(i).c_str());
+			u::log::print("  %d) %s\n", i, getDeviceName(i));
 	}
 
 	RtAudio::StreamParameters outParams;
@@ -206,7 +206,7 @@ int openDevice()
 		return 1;
 	}
 	catch (RtAudioError &e) {
-		u::log::print("[KA] rtSystem init error: %s\n", e.getMessage().c_str());
+		u::log::print("[KA] rtSystem init error: %s\n", e.getMessage());
 		closeDevice();
 		return 0;
 	}
@@ -224,7 +224,7 @@ int startStream()
 		return 1;
 	}
 	catch (RtAudioError &e) {
-		u::log::print("[KA] Start stream error: %s\n", e.getMessage().c_str());
+		u::log::print("[KA] Start stream error: %s\n", e.getMessage());
 		return 0;
 	}
 }

--- a/src/core/kernelMidi.cpp
+++ b/src/core/kernelMidi.cpp
@@ -99,7 +99,7 @@ int openOutDevice(int port)
 		status_  = true;
 	}
 	catch (RtMidiError &error) {
-		u::log::print("[KM] MIDI out device error: %s\n", error.getMessage().c_str());
+		u::log::print("[KM] MIDI out device error: %s\n", error.getMessage());
 		status_ = false;
 		return 0;
 	}
@@ -109,7 +109,7 @@ int openOutDevice(int port)
 	numOutPorts_ = midiOut_->getPortCount();
 	u::log::print("[KM] %d output MIDI ports found\n", numOutPorts_);
 	for (unsigned i=0; i<numOutPorts_; i++)
-		u::log::print("  %d) %s\n", i, getOutPortName(i).c_str());
+		u::log::print("  %d) %s\n", i, getOutPortName(i));
 
 	/* try to open a port, if enabled */
 
@@ -125,7 +125,7 @@ int openOutDevice(int port)
 			return 1;
 		}
 		catch (RtMidiError& error) {
-			u::log::print("[KM] unable to open MIDI out port %d: %s\n", port, error.getMessage().c_str());
+			u::log::print("[KM] unable to open MIDI out port %d: %s\n", port, error.getMessage());
 			status_ = false;
 			return 0;
 		}
@@ -145,7 +145,7 @@ int openInDevice(int port)
 		status_ = true;
 	}
 	catch (RtMidiError &error) {
-		u::log::print("[KM] MIDI in device error: %s\n", error.getMessage().c_str());
+		u::log::print("[KM] MIDI in device error: %s\n", error.getMessage());
 		status_ = false;
 		return 0;
 	}
@@ -155,7 +155,7 @@ int openInDevice(int port)
 	numInPorts_ = midiIn_->getPortCount();
 	u::log::print("[KM] %d input MIDI ports found\n", numInPorts_);
 	for (unsigned i=0; i<numInPorts_; i++)
-		u::log::print("  %d) %s\n", i, getInPortName(i).c_str());
+		u::log::print("  %d) %s\n", i, getInPortName(i));
 
 	/* try to open a port, if enabled */
 
@@ -168,7 +168,7 @@ int openInDevice(int port)
 			return 1;
 		}
 		catch (RtMidiError& error) {
-			u::log::print("[KM] unable to open MIDI in port %d: %s\n", port, error.getMessage().c_str());
+			u::log::print("[KM] unable to open MIDI in port %d: %s\n", port, error.getMessage());
 			status_ = false;
 			return 0;
 		}

--- a/src/core/midiMapConf.cpp
+++ b/src/core/midiMapConf.cpp
@@ -116,7 +116,7 @@ void parse_(Message& message)
 	message.value = strtoul(output.c_str(), nullptr, 16);
 
 	u::log::print("[parse] parsed chan=%d valueStr=%s value=%#x, offset=%d\n",
-			message.channel, message.valueStr.c_str(), message.value, message.offset);
+			message.channel, message.valueStr, message.value, message.offset);
 }
 } // {anonymous}
 
@@ -141,7 +141,7 @@ void init()
 	/* scan dir of midi maps and load the filenames into <>maps. */
 
 	u::log::print("[midiMapConf::init] scanning midimaps directory '%s'...\n",
-		midimapsPath.c_str());
+		midimapsPath);
 
 	if (!std::filesystem::exists(midimapsPath)) {
 		u::log::print("[midiMapConf::init] unable to scan midimaps directory!\n");
@@ -152,7 +152,7 @@ void init()
 		// TODO - check if is a valid midimap file (verify headers)
 		if (!d.is_regular_file())
 			continue;
-		u::log::print("[midiMapConf::init] found midimap '%s'\n", d.path().filename().string().c_str());
+		u::log::print("[midiMapConf::init] found midimap '%s'\n", d.path().filename().string());
 		maps.push_back(d.path().filename().string());
 	}
 
@@ -188,7 +188,7 @@ int read(const std::string& file)
 		return MIDIMAP_NOT_SPECIFIED;
 	}
 
-	u::log::print("[midiMapConf::read] reading midimap file '%s'\n", file.c_str());
+	u::log::print("[midiMapConf::read] reading midimap file '%s'\n", file);
 
 	std::ifstream ifs(midimapsPath + file);
 	if (!ifs.good())

--- a/src/core/pluginManager.cpp
+++ b/src/core/pluginManager.cpp
@@ -106,7 +106,7 @@ void init(int samplerate, int buffersize)
 
 int scanDirs(const std::string& dirs, const std::function<void(float)>& cb)
 {
-	u::log::print("[pluginManager::scanDir] requested directories: '%s'\n", dirs.c_str());
+	u::log::print("[pluginManager::scanDir] requested directories: '%s'\n", dirs);
 	u::log::print("[pluginManager::scanDir] current plugins: %d\n", knownPluginList_.getNumTypes());
 
 	knownPluginList_.clear();   // clear up previous plugins
@@ -141,7 +141,7 @@ bool saveList(const std::string& filepath)
 {
 	bool out = knownPluginList_.createXml()->writeTo(juce::File(filepath));
 	if (!out)
-		u::log::print("[pluginManager::saveList] unable to save plugin list to %s\n", filepath.c_str());
+		u::log::print("[pluginManager::saveList] unable to save plugin list to %s\n", filepath);
 	return out;
 }
 
@@ -171,19 +171,19 @@ std::unique_ptr<Plugin> makePlugin(const std::string& pid, ID id)
 
 	const std::unique_ptr<juce::PluginDescription> pd = knownPluginList_.getTypeForIdentifierString(pid);
 	if (pd == nullptr) {
-		u::log::print("[pluginManager::makePlugin] no plugin found with pid=%s!\n", pid.c_str());
+		u::log::print("[pluginManager::makePlugin] no plugin found with pid=%s!\n", pid);
 		return makeInvalidPlugin_(pid, id);
 	}
 
 	juce::String error;
 	std::unique_ptr<juce::AudioPluginInstance> pi = formatManager_.createPluginInstance(*pd, samplerate_, buffersize_, error);
 	if (pi == nullptr) {
-		u::log::print("[pluginManager::makePlugin] unable to create instance with pid=%s! Error: %s\n", 
-			pid.c_str(), error.toStdString().c_str());
+		u::log::print("[pluginManager::makePlugin] unable to create instance with pid=%s! Error: %s\n",
+			pid, error.toStdString());
 		return makeInvalidPlugin_(pid, id);
 	}
 
-	u::log::print("[pluginManager::makePlugin] plugin instance with pid=%s created\n", pid.c_str());
+	u::log::print("[pluginManager::makePlugin] plugin instance with pid=%s created\n", pid);
 
 	return std::make_unique<Plugin>(pluginId_.get(id), std::move(pi), samplerate_, buffersize_);
 }

--- a/src/core/waveManager.cpp
+++ b/src/core/waveManager.cpp
@@ -88,7 +88,7 @@ void init()
 Result createFromFile(const std::string& path, ID id, int samplerate, int quality)
 {
 	if (path == "" || u::fs::isDir(path)) {
-		u::log::print("[waveManager::create] malformed path (was '%s')\n", path.c_str());
+		u::log::print("[waveManager::create] malformed path (was '%s')\n", path);
 		return { G_RES_ERR_NO_DATA };
 	}
 
@@ -99,7 +99,7 @@ Result createFromFile(const std::string& path, ID id, int samplerate, int qualit
 	SNDFILE* fileIn = sf_open(path.c_str(), SFM_READ, &header);
 
 	if (fileIn == nullptr) {
-		u::log::print("[waveManager::create] unable to read %s. %s\n", path.c_str(), sf_strerror(fileIn));
+		u::log::print("[waveManager::create] unable to read %s. %s\n", path, sf_strerror(fileIn));
 		return { G_RES_ERR_IO };
 	}
 
@@ -230,7 +230,7 @@ int save(const Wave& w, const std::string& path)
 	SNDFILE* file = sf_open(path.c_str(), SFM_WRITE, &header);
 	if (file == nullptr) {
 		u::log::print("[waveManager::save] unable to open %s for exporting: %s\n",
-			path.c_str(), sf_strerror(file));
+			path, sf_strerror(file));
 		return G_RES_ERR_IO;
 	}
 

--- a/src/glue/main.cpp
+++ b/src/glue/main.cpp
@@ -88,7 +88,7 @@ void setBpm_(float current, std::string s)
 		G_MainWin->mainTimer->setBpm(s.c_str());
 	}
 
-	u::log::print("[glue::setBpm_] Bpm changed to %s (real=%f)\n", s.c_str(), m::clock::getBpm());
+	u::log::print("[glue::setBpm_] Bpm changed to %s (real=%f)\n", s, m::clock::getBpm());
 }
 } // {anonymous}
 

--- a/src/glue/storage.cpp
+++ b/src/glue/storage.cpp
@@ -114,7 +114,7 @@ bool savePatch_(const std::string& path, const std::string& name)
 
 	u::gui::updateMainWinLabel(name);
 	m::conf::conf.patchPath = u::fs::getUpDir(u::fs::getUpDir(path));
-	u::log::print("[savePatch] patch saved as %s\n", path.c_str());
+	u::log::print("[savePatch] patch saved as %s\n", path);
 
 	return true;
 }
@@ -150,7 +150,7 @@ void loadProject(void* data)
 
 	browser->showStatusBar();
 
-	u::log::print("[loadProject] load from %s\n", fullPath.c_str());
+	u::log::print("[loadProject] load from %s\n", fullPath);
 
 	std::string fileToLoad = fullPath;  // patch file to read from
 	std::string basePath   = "";        // base path, in case of reading from a project
@@ -239,7 +239,7 @@ void saveProject(void* data)
 		return;
 	}
 
-	u::log::print("[saveProject] Project dir created: %s\n", fullPath.c_str());
+	u::log::print("[saveProject] Project dir created: %s\n", fullPath);
 
 	saveWavesToProject_(fullPath);
 
@@ -306,9 +306,9 @@ void saveSample(void* data)
 		v::gdAlert("Unable to save this sample!");
 		return;
 	}
-	
-	u::log::print("[saveSample] sample saved to %s\n", filePath.c_str());
-	
+
+	u::log::print("[saveSample] sample saved to %s\n", filePath);
+
 	/* Update last used path in conf, so that it can be reused next time. */
 
 	m::conf::conf.samplePath = u::fs::dirname(filePath);

--- a/src/utils/log.cpp
+++ b/src/utils/log.cpp
@@ -28,37 +28,19 @@
 
 
 #include <cstdio>
-#include <cstdarg>
 #include <string>
-#include "utils/fs.h"
-#include "core/const.h"
 #include "log.h"
 
 
-namespace giada {
-namespace u {
-namespace log 
-{
-namespace
-{
-FILE* f;
-int   mode;
-bool  stat;
-} // {anonymouse}
+namespace giada::u {
 
-
-/* -------------------------------------------------------------------------- */
-/* -------------------------------------------------------------------------- */
-/* -------------------------------------------------------------------------- */
-
-
-int init(int m)
+int log::init(int m)
 {
 	mode = m;
 	stat = true;
 	if (mode == LOG_MODE_FILE) {
 		std::string fpath = fs::getHomePath() + G_SLASH + "giada.log";
-		f = fopen(fpath.c_str(), "a");
+		f = std::fopen(fpath.c_str(), "a");
 		if (!f) {
 			stat = false;
 			return 0;
@@ -71,30 +53,10 @@ int init(int m)
 /* -------------------------------------------------------------------------- */
 
 
-void close()
+void log::close()
 {
 	if (mode == LOG_MODE_FILE)
-		fclose(f);
+		std::fclose(f);
 }
 
-
-/* -------------------------------------------------------------------------- */
-
-
-void print(const char* format, ...)
-{
-	if (mode == LOG_MODE_MUTE)
-		return;
-	va_list args;
-	va_start(args, format);
-	if (mode == LOG_MODE_FILE && stat == true) {
-		vfprintf(f, format, args);
-#ifdef _WIN32
-		fflush(f);
-#endif
-	}
-  	else
-		vprintf(format, args);
-	va_end(args);
-}
-}}}  // giada::u::log::
+}  // giada::u

--- a/src/utils/log.cpp
+++ b/src/utils/log.cpp
@@ -31,10 +31,9 @@
 #include <string>
 #include "log.h"
 
+namespace giada::u::log {
 
-namespace giada::u {
-
-int log::init(int m)
+int init(int m)
 {
 	mode = m;
 	stat = true;
@@ -53,10 +52,10 @@ int log::init(int m)
 /* -------------------------------------------------------------------------- */
 
 
-void log::close()
+void close()
 {
 	if (mode == LOG_MODE_FILE)
 		std::fclose(f);
 }
 
-}  // giada::u
+}  // giada::u::log

--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -38,19 +38,18 @@
 #include "utils/fs.h"
 #include "core/const.h"
 
-namespace giada::u {
+namespace giada::u::log {
 
-struct log {
-  static inline FILE* f;
-  static inline int   mode;
-  static inline bool  stat;
+  inline FILE* f;
+  inline int   mode;
+  inline bool  stat;
 
   /* init
   Initializes logger. Mode defines where to write the output: LOG_MODE_STDOUT,
   LOG_MODE_FILE and LOG_MODE_MUTE. */
-  static int init(int mode);
+  int init(int mode);
 
-  static void close();
+  void close();
 
   // Use forwarding references && to avoid useless string copy
   static constexpr auto string_to_c_str = [] (auto&& s) {
@@ -89,8 +88,6 @@ struct log {
       std::printf(format, string_to_c_str(std::forward<Args>(args))...);
   }
 
-};
-
-}  // giada::u
+}  // giada::u::log
 
 #endif

--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -30,21 +30,67 @@
 #ifndef G_UTILS_LOG_H
 #define G_UTILS_LOG_H
 
+#include <cstdio>
+#include <string>
+#include <type_traits>
+#include <utility>
 
-namespace giada {
-namespace u {
-namespace log 
-{
-/* init
-Initializes logger. Mode defines where to write the output: LOG_MODE_STDOUT,
-LOG_MODE_FILE and LOG_MODE_MUTE. */
+#include "utils/fs.h"
+#include "core/const.h"
 
-int init(int mode);
+namespace giada::u {
 
-void close();
+struct log {
+  static inline FILE* f;
+  static inline int   mode;
+  static inline bool  stat;
 
-void print(const char* format, ...);
-}}}  // giada::u::log::
+  /* init
+  Initializes logger. Mode defines where to write the output: LOG_MODE_STDOUT,
+  LOG_MODE_FILE and LOG_MODE_MUTE. */
+  static int init(int mode);
 
+  static void close();
+
+  // Use forwarding references && to avoid useless string copy
+  static constexpr auto string_to_c_str = [] (auto&& s) {
+    // Remove any reference and const-ness, since the function can
+    // handle l-value and r-value, const or not.
+    // Use std::remove_cvref instead, when sitching to C++20...
+    if constexpr (std::is_same_v<std::remove_const_t<std::remove_reference_t<
+                                   decltype(s)>>,
+                                 std::string>)
+      // If the argument is a std::string return an old-style C-string
+      return s.c_str();
+    else
+      // Return the argument unchanged otherwise
+      return s;
+  };
+
+  /** A variadic printf-like logging fonction
+
+      Any `std::string` argument will be automatically transformed
+      into a C-string.
+
+      Use forwarding references to avoid useless string copy. */
+  template <typename... Args>
+  static void print(const char* format, Args&&... args) {
+    if (mode == LOG_MODE_MUTE)
+      return;
+
+    if (mode == LOG_MODE_FILE && stat == true) {
+      // Replace any std::string in the arguments by its C-string
+      std::fprintf(f, format, string_to_c_str(std::forward<Args>(args))...);
+#ifdef _WIN32
+      fflush(f);
+#endif
+    }
+    else
+      std::printf(format, string_to_c_str(std::forward<Args>(args))...);
+  }
+
+};
+
+}  // giada::u
 
 #endif

--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -40,53 +40,53 @@
 
 namespace giada::u::log {
 
-  inline FILE* f;
-  inline int   mode;
-  inline bool  stat;
+	inline FILE* f;
+	inline int   mode;
+	inline bool  stat;
 
-  /* init
-  Initializes logger. Mode defines where to write the output: LOG_MODE_STDOUT,
-  LOG_MODE_FILE and LOG_MODE_MUTE. */
-  int init(int mode);
+	/* init
+	Initializes logger. Mode defines where to write the output: LOG_MODE_STDOUT,
+	LOG_MODE_FILE and LOG_MODE_MUTE. */
+	int init(int mode);
 
-  void close();
+	void close();
 
-  // Use forwarding references && to avoid useless string copy
-  static constexpr auto string_to_c_str = [] (auto&& s) {
-    // Remove any reference and const-ness, since the function can
-    // handle l-value and r-value, const or not.
-    // Use std::remove_cvref instead, when sitching to C++20...
-    if constexpr (std::is_same_v<std::remove_const_t<std::remove_reference_t<
-                                   decltype(s)>>,
-                                 std::string>)
-      // If the argument is a std::string return an old-style C-string
-      return s.c_str();
-    else
-      // Return the argument unchanged otherwise
-      return s;
-  };
+	// Use forwarding references && to avoid useless string copy
+	static constexpr auto string_to_c_str = [] (auto&& s) {
+		// Remove any reference and const-ness, since the function can
+		// handle l-value and r-value, const or not.
+		// Use std::remove_cvref instead, when sitching to C++20...
+		if constexpr (std::is_same_v<std::remove_const_t<std::remove_reference_t<
+			decltype(s)>>,
+			std::string>)
+			// If the argument is a std::string return an old-style C-string
+			return s.c_str();
+		else
+			// Return the argument unchanged otherwise
+			return s;
+	};
 
-  /** A variadic printf-like logging fonction
+	/** A variadic printf-like logging fonction
 
-      Any `std::string` argument will be automatically transformed
-      into a C-string.
+			Any `std::string` argument will be automatically transformed
+			into a C-string.
 
-      Use forwarding references to avoid useless string copy. */
-  template <typename... Args>
-  static void print(const char* format, Args&&... args) {
-    if (mode == LOG_MODE_MUTE)
-      return;
+			Use forwarding references to avoid useless string copy. */
+	template <typename... Args>
+	static void print(const char* format, Args&&... args) {
+		if (mode == LOG_MODE_MUTE)
+			return;
 
-    if (mode == LOG_MODE_FILE && stat == true) {
-      // Replace any std::string in the arguments by its C-string
-      std::fprintf(f, format, string_to_c_str(std::forward<Args>(args))...);
+		if (mode == LOG_MODE_FILE && stat == true) {
+			// Replace any std::string in the arguments by its C-string
+			std::fprintf(f, format, string_to_c_str(std::forward<Args>(args))...);
 #ifdef _WIN32
-      fflush(f);
+			fflush(f);
 #endif
-    }
-    else
-      std::printf(format, string_to_c_str(std::forward<Args>(args))...);
-  }
+		}
+		else
+			std::printf(format, string_to_c_str(std::forward<Args>(args))...);
+	}
 
 }  // giada::u::log
 


### PR DESCRIPTION
Save a lot of `.c_str()` from the code.
Take advantage of C++17.
Probably the design of `giada::u::log` could be modernized to be less C-oriented, but this is another story.
This address comment discussion from https://github.com/monocasual/giada/pull/398#discussion_r498428677