### PR TITLE
Add missing file to Makefile.am so giada builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -54,6 +54,7 @@ sourcesCore =                               \
 	src/core/kernelMidi.cpp                 \
 	src/core/graphics.h                     \
 	src/core/graphics.cpp                   \
+	src/core/midiLearnParam.cpp             \
 	src/core/patch.h                        \
 	src/core/patch.cpp                      \
 	src/core/recorderHandler.h              \


### PR DESCRIPTION
I couldn't link giada when doing the usual `./autogen.sh; configure --target=osx; make -j8` routine; I think this one file was missing from the build system. anyways this fixes it