### PR TITLE
Add missing include for std::string

### DIFF
--- a/src/gui/dialogs/browser/browserBase.h
+++ b/src/gui/dialogs/browser/browserBase.h
@@ -30,6 +30,7 @@
 #include "core/types.h"
 #include "gui/dialogs/window.h"
 #include <functional>
+#include <string>
 
 class Fl_Group;
 class geCheck;


### PR DESCRIPTION
src/gui/dialogs/browser/browserBase.h:
Add missing include for std::string.

Fixes #454