### PR TITLE
Install executable to FHS compliant location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,7 +530,8 @@ target_compile_options(giada PRIVATE ${COMPILER_OPTIONS})
 # Install rules
 # ------------------------------------------------------------------------------
 
-install(TARGETS giada DESTINATION ${CMAKE_INSTALL_PREFIX})
+include(GNUInstallDirs)
+install(TARGETS giada DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})
 
 # ------------------------------------------------------------------------------
 # Extra


### PR DESCRIPTION
CMakeLists.txt:
Use the GNUInstallDirs module [1] to install the standalone executable
to the correct location on Unix-like systems.

Fixes #450

[1] https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html