### PR TITLE
Replacing all ssh links in .gitmodules with https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,10 +12,10 @@
 	url = https://github.com/monocasual/rtaudio.git
 [submodule "src/deps/geompp"]
 	path = src/deps/geompp
-	url = git@github.com:monocasual/geompp.git
+	url = https://github.com/monocasual/geompp.git
 [submodule "src/deps/mcl-audio-buffer"]
 	path = src/deps/mcl-audio-buffer
-	url = git@github.com:monocasual/mcl-audio-buffer.git
+	url = https://github.com/monocasual/mcl-audio-buffer.git
 [submodule "src/deps/mcl-atomic-swapper"]
 	path = src/deps/mcl-atomic-swapper
-	url = git@github.com:monocasual/mcl-atomic-swapper.git
+	url = https://github.com/monocasual/mcl-atomic-swapper.git


### PR DESCRIPTION
 Because of that, I couldn't properly fetch all submodules on my system (NixOS)
 
I think it'll be better to replace all `ssh` links with `http`. Anyway,  that change don't have strong affect 
