### PR TITLE
Fix cmake pthread use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,8 +264,9 @@ endif()
 
 # Threads (system)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
-list(APPEND LIBRARIES ${Threads_LIBRARY})
+list(APPEND LIBRARIES Threads::Threads)
 
 # pkg-config/pkgconf, required to find some external dependencies on some
 # platforms


### PR DESCRIPTION
Let cmake use -pthread instead of -lpthread, to fix build error on riscv64.

FYI:
https://stackoverflow.com/questions/23250863/difference-between-pthread-and-lpthread-while-compiling
https://stackoverflow.com/questions/1620918/cmake-and-libpthread
https://cmake.org/cmake/help/latest/module/FindThreads.html#variable:THREADS_PREFER_PTHREAD_FLAG

BTW: `${Threads_LIBRARY}` seems to be an undefined variable.