### PR TITLE
Reference the correct icon in XDG desktop file

### DIFF
--- a/extras/com.giadamusic.Giada.desktop
+++ b/extras/com.giadamusic.Giada.desktop
@@ -7,6 +7,6 @@ GenericName=Drum machine and loop sequencer
 GenericName[es]=Caja de ritmos y secuenciador de loops
 Exec=giada %f
 Terminal=false
-Icon=giada-logo
+Icon=com.giadamusic.Giada
 Categories=Music;AudioVideo;Audio;Midi;X-Digital_Processing;X-Jack;X-MIDI;
 Keywords=Giada;


### PR DESCRIPTION
extras/com.giadamusic.Giada.desktop:
Use the correct file name for the logo (it is installed as
com.giadamusic.Giada.svg).