### PR TITLE
Include <memory> where std::unique_ptr is used

### DIFF
--- a/src/core/channels/channelManager.cpp
+++ b/src/core/channels/channelManager.cpp
@@ -36,6 +36,7 @@
 #include "core/wave.h"
 #include "glue/channel.h"
 #include <cassert>
+#include <memory>
 
 namespace giada::m
 {

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -29,6 +29,7 @@
 #include "core/model/storage.h"
 #include "utils/fs.h"
 #include "utils/log.h"
+#include <memory>
 
 namespace giada::m
 {

--- a/src/core/kernelMidi.cpp
+++ b/src/core/kernelMidi.cpp
@@ -28,6 +28,7 @@
 #include "core/const.h"
 #include "utils/log.h"
 #include <cassert>
+#include <memory>
 
 namespace giada::m
 {

--- a/src/core/mixerHandler.cpp
+++ b/src/core/mixerHandler.cpp
@@ -39,6 +39,7 @@
 #include "utils/vector.h"
 #include <algorithm>
 #include <cassert>
+#include <memory>
 #include <vector>
 
 namespace giada::m

--- a/src/core/model/model.cpp
+++ b/src/core/model/model.cpp
@@ -26,6 +26,7 @@
 
 #include "core/model/model.h"
 #include <cassert>
+#include <memory>
 #ifdef G_DEBUG_MODE
 #include "core/channels/channelManager.h"
 #endif

--- a/src/core/model/model.h
+++ b/src/core/model/model.h
@@ -39,6 +39,7 @@
 #include "deps/mcl-audio-buffer/src/audioBuffer.hpp"
 #include "src/core/actions/actions.h"
 #include "utils/vector.h"
+#include <memory>
 
 namespace giada::m::model
 {

--- a/src/core/model/storage.cpp
+++ b/src/core/model/storage.cpp
@@ -36,6 +36,7 @@
 #include "core/waveManager.h"
 #include "src/core/actions/actionRecorder.h"
 #include <cassert>
+#include <memory>
 
 extern giada::m::Engine g_engine;
 

--- a/src/core/plugins/plugin.cpp
+++ b/src/core/plugins/plugin.cpp
@@ -32,6 +32,7 @@
 #include "utils/time.h"
 #include <FL/Fl.H>
 #include <cassert>
+#include <memory>
 
 namespace giada::m
 {

--- a/src/core/plugins/plugin.h
+++ b/src/core/plugins/plugin.h
@@ -34,6 +34,7 @@
 #include "core/plugins/pluginHost.h"
 #include "core/plugins/pluginState.h"
 #include "deps/juce-config.h"
+#include <memory>
 #include <vector>
 
 namespace giada::m

--- a/src/core/plugins/pluginHost.cpp
+++ b/src/core/plugins/pluginHost.cpp
@@ -36,6 +36,7 @@
 #include "utils/log.h"
 #include "utils/vector.h"
 #include <cassert>
+#include <memory>
 
 namespace giada::m
 {

--- a/src/core/plugins/pluginHost.h
+++ b/src/core/plugins/pluginHost.h
@@ -32,6 +32,7 @@
 #include "core/types.h"
 #include "deps/juce-config.h"
 #include <functional>
+#include <memory>
 
 namespace mcl
 {

--- a/src/core/plugins/pluginManager.cpp
+++ b/src/core/plugins/pluginManager.cpp
@@ -35,6 +35,7 @@
 #include "utils/log.h"
 #include "utils/string.h"
 #include <cassert>
+#include <memory>
 
 namespace giada::m
 {

--- a/src/core/plugins/pluginManager.h
+++ b/src/core/plugins/pluginManager.h
@@ -33,6 +33,7 @@
 #include "core/patch.h"
 #include "deps/juce-config.h"
 #include "plugin.h"
+#include <memory>
 
 namespace giada::m::patch
 {

--- a/src/core/waveManager.cpp
+++ b/src/core/waveManager.cpp
@@ -34,6 +34,7 @@
 #include "wave.h"
 #include "waveFx.h"
 #include <cmath>
+#include <memory>
 #include <samplerate.h>
 #include <sndfile.h>
 

--- a/src/glue/plugin.cpp
+++ b/src/glue/plugin.cpp
@@ -44,6 +44,7 @@
 #include "utils/gui.h"
 #include <FL/Fl.H>
 #include <cassert>
+#include <memory>
 
 extern giada::v::Ui     g_ui;
 extern giada::m::Engine g_engine;

--- a/src/glue/sampleEditor.cpp
+++ b/src/glue/sampleEditor.cpp
@@ -54,6 +54,7 @@
 #include "utils/log.h"
 #include <FL/Fl.H>
 #include <cassert>
+#include <memory>
 
 extern giada::v::Ui     g_ui;
 extern giada::m::Engine g_engine;

--- a/src/gui/dialogs/pluginWindowGUI.h
+++ b/src/gui/dialogs/pluginWindowGUI.h
@@ -36,6 +36,7 @@
 #include "window.h"
 #include <FL/Fl.H>
 #include <FL/Fl_Window.H>
+#include <memory>
 
 namespace giada::c::plugin
 {

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -31,6 +31,7 @@
 #include <climits>
 #include <cstdarg>
 #include <iomanip>
+#include <memory>
 
 namespace giada
 {


### PR DESCRIPTION
Include the `memory` header where `std::unique_ptr` is used.

This is far from a full implementation of the “include what you use” concept, and indeed the [tool of that name](https://include-what-you-use.org/) could be helpful, but it does fix a concrete failure to compile on GCC 12.0.1, in which an implicit recursive include via another header was no longer present.

```
/builddir/build/BUILD/giada-0.20.0/src/utils/string.cpp: In function 'std::string giada::u::string::format(const char*, ...)':
/builddir/build/BUILD/giada-0.20.0/src/utils/string.cpp:87:14: error: 'unique_ptr' is not a member of 'std'
   87 |         std::unique_ptr<char[]> tmp(new char[size]);
      |              ^~~~~~~~~~
/builddir/build/BUILD/giada-0.20.0/src/utils/string.cpp:34:1: note: 'std::unique_ptr' is defined in header '<memory>'; did you forget to '#include <memory>'?
   33 | #include <iomanip>
  +++ |+#include <memory>
   34 | 
/builddir/build/BUILD/giada-0.20.0/src/utils/string.cpp:87:25: error: expected primary-expression before 'char'
   87 |         std::unique_ptr<char[]> tmp(new char[size]);
      |                         ^~~~
/builddir/build/BUILD/giada-0.20.0/src/utils/string.cpp:92:18: error: 'tmp' was not declared in this scope; did you mean 'tm'?
   92 |         vsprintf(tmp.get(), format, args);
      |                  ^~~
      |                  tm
```