### PR TITLE
Include <cstddef> where std::size_t is used

### DIFF
--- a/src/core/actions/actionRecorder.cpp
+++ b/src/core/actions/actionRecorder.cpp
@@ -35,6 +35,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstddef>
 #include <unordered_map>
 
 namespace giada::m

--- a/src/core/actions/actionRecorder.h
+++ b/src/core/actions/actionRecorder.h
@@ -30,6 +30,7 @@
 #include "core/actions/actions.h"
 #include "core/midiEvent.h"
 #include "core/types.h"
+#include <cstddef>
 #include <unordered_set>
 
 namespace giada::m::patch

--- a/src/core/kernelAudio.cpp
+++ b/src/core/kernelAudio.cpp
@@ -32,6 +32,7 @@
 #include "utils/log.h"
 #include "utils/vector.h"
 #include <cassert>
+#include <cstddef>
 
 namespace giada::m
 {

--- a/src/core/kernelAudio.h
+++ b/src/core/kernelAudio.h
@@ -29,6 +29,7 @@
 
 #include "core/conf.h"
 #include "deps/rtaudio/RtAudio.h"
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <string>

--- a/src/core/midiDispatcher.cpp
+++ b/src/core/midiDispatcher.cpp
@@ -38,6 +38,7 @@
 #include "utils/log.h"
 #include "utils/math.h"
 #include <cassert>
+#include <cstddef>
 #include <vector>
 
 namespace giada::m

--- a/src/core/midiDispatcher.h
+++ b/src/core/midiDispatcher.h
@@ -31,6 +31,7 @@
 #include "core/midiEvent.h"
 #include "core/model/model.h"
 #include "core/types.h"
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 

--- a/src/core/midiLearnParam.cpp
+++ b/src/core/midiLearnParam.cpp
@@ -25,6 +25,7 @@
  * -------------------------------------------------------------------------- */
 
 #include "midiLearnParam.h"
+#include <cstddef>
 
 namespace giada::m
 {

--- a/src/core/midiLearnParam.h
+++ b/src/core/midiLearnParam.h
@@ -28,6 +28,7 @@
 #define G_MIDI_LEARN_PARAM_H
 
 #include "core/weakAtomic.h"
+#include <cstddef>
 #include <atomic>
 
 namespace giada::m

--- a/src/core/midiMapper.cpp
+++ b/src/core/midiMapper.cpp
@@ -31,6 +31,7 @@
 #include "utils/fs.h"
 #include "utils/log.h"
 #include "utils/string.h"
+#include <cstddef>
 #include <cstring>
 #include <filesystem>
 #include <fstream>

--- a/src/core/plugins/pluginHost.cpp
+++ b/src/core/plugins/pluginHost.cpp
@@ -36,6 +36,7 @@
 #include "utils/log.h"
 #include "utils/vector.h"
 #include <cassert>
+#include <cstddef>
 #include <memory>
 
 namespace giada::m

--- a/src/core/plugins/pluginManager.cpp
+++ b/src/core/plugins/pluginManager.cpp
@@ -35,6 +35,7 @@
 #include "utils/log.h"
 #include "utils/string.h"
 #include <cassert>
+#include <cstddef>
 #include <memory>
 
 namespace giada::m

--- a/src/core/plugins/pluginState.cpp
+++ b/src/core/plugins/pluginState.cpp
@@ -28,6 +28,7 @@
 
 #include "pluginState.h"
 #include "core/const.h"
+#include <cstddef>
 
 namespace giada::m
 {

--- a/src/core/plugins/pluginState.h
+++ b/src/core/plugins/pluginState.h
@@ -30,6 +30,7 @@
 #define G_PLUGIN_STATE_H
 
 #include "deps/juce-config.h"
+#include <cstddef>
 #include <string>
 
 namespace giada::m

--- a/src/core/queue.h
+++ b/src/core/queue.h
@@ -27,6 +27,7 @@
 #ifndef G_QUEUE_H
 #define G_QUEUE_H
 
+#include <cstddef>
 #include <array>
 #include <atomic>
 

--- a/src/core/ringBuffer.h
+++ b/src/core/ringBuffer.h
@@ -27,6 +27,7 @@
 #ifndef G_RING_BUFFER_H
 #define G_RING_BUFFER_H
 
+#include <cstddef>
 #include <array>
 
 namespace giada

--- a/src/glue/config.cpp
+++ b/src/glue/config.cpp
@@ -41,6 +41,7 @@
 #include "utils/fs.h"
 #include "utils/vector.h"
 #include <FL/Fl_Tooltip.H>
+#include <cstddef>
 
 extern giada::v::Ui     g_ui;
 extern giada::m::Engine g_engine;

--- a/src/gui/dialogs/midiIO/midiInputChannel.cpp
+++ b/src/gui/dialogs/midiIO/midiInputChannel.cpp
@@ -30,6 +30,7 @@
 #include "utils/log.h"
 #include <FL/Fl_Pack.H>
 #include <cassert>
+#include <cstddef>
 #ifdef WITH_VST
 #include "core/plugins/plugin.h"
 #endif

--- a/src/gui/elems/basics/flex.cpp
+++ b/src/gui/elems/basics/flex.cpp
@@ -1,4 +1,5 @@
 #include "flex.h"
+#include <cstddef>
 #include <numeric>
 
 namespace giada::v

--- a/src/gui/elems/basics/group.cpp
+++ b/src/gui/elems/basics/group.cpp
@@ -28,6 +28,7 @@
  * -------------------------------------------------------------------------- */
 
 #include "group.h"
+#include <cstddef>
 #include <algorithm>
 
 namespace giada

--- a/src/gui/elems/basics/group.h
+++ b/src/gui/elems/basics/group.h
@@ -31,6 +31,7 @@
 #define GE_GROUP_H
 
 #include <FL/Fl_Group.H>
+#include <cstddef>
 #include <vector>
 
 namespace giada

--- a/src/gui/elems/basics/resizerBar.cpp
+++ b/src/gui/elems/basics/resizerBar.cpp
@@ -30,6 +30,7 @@
 #include <FL/Fl_Group.H>
 #include <FL/fl_draw.H>
 #include <cassert>
+#include <cstddef>
 #include <vector>
 
 namespace giada::v

--- a/src/gui/elems/basics/scrollPack.cpp
+++ b/src/gui/elems/basics/scrollPack.cpp
@@ -28,6 +28,7 @@
 #include "boxtypes.h"
 #include "core/const.h"
 #include <cassert>
+#include <cstddef>
 
 namespace giada
 {

--- a/src/gui/elems/basics/scrollPack.h
+++ b/src/gui/elems/basics/scrollPack.h
@@ -29,6 +29,7 @@
 
 #include "gui/elems/basics/pack.h"
 #include "gui/elems/basics/scroll.h"
+#include <cstddef>
 
 namespace giada
 {

--- a/src/utils/gui.cpp
+++ b/src/utils/gui.cpp
@@ -26,6 +26,7 @@
 
 #include <FL/Fl.H>
 #include <FL/fl_draw.H>
+#include <cstddef>
 #include <string>
 #if defined(_WIN32)
 #include "../ext/resource.h"

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -30,6 +30,7 @@
 #include "core/const.h"
 #include <climits>
 #include <cstdarg>
+#include <cstddef>
 #include <iomanip>
 #include <memory>
 

--- a/src/utils/vector.h
+++ b/src/utils/vector.h
@@ -27,6 +27,7 @@
 #ifndef G_UTILS_VECTOR_H
 #define G_UTILS_VECTOR_H
 
+#include <cstddef>
 #include <algorithm>
 #include <functional>
 #include <vector>


### PR DESCRIPTION
Include the `cstddef` header where `std::size_t` is used.

This is far from a full implementation of the “include what you use” concept, and indeed the [tool of that name](https://include-what-you-use.org/) could be helpful, but it does fix a concrete failure to compile on GCC 12.0.1, in which an implicit recursive include via another header was no longer present.

```
[159/172] /usr/bin/g++ -DNDEBUG -DTEST_RESOURCES_DIR=\"/builddir/build/BUILD/giada-0.20.1/tests/resources/\" -DWITH_AUDIO_JACK -DWITH_TESTS -D__LINUX_ALSA__ -D__LINUX_PULSE__ -D__UNIX_JACK__ -I/builddir/build/BUILD/giada-0.20.1 -I/builddir/build/BUILD/giada-0.20.1/src -isystem /usr/include/rtmidi -isystem /usr/include/opus -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -Wall -Wextra -Wpedantic -pthread -D__UNIX_JACK__ -D__LINUX_ALSA__ -MD -MT CMakeFiles/giada.dir/src/gui/elems/basics/flex.cpp.o -MF CMakeFiles/giada.dir/src/gui/elems/basics/flex.cpp.o.d -o CMakeFiles/giada.dir/src/gui/elems/basics/flex.cpp.o -c /builddir/build/BUILD/giada-0.20.1/src/gui/elems/basics/flex.cpp
FAILED: CMakeFiles/giada.dir/src/gui/elems/basics/flex.cpp.o 
/usr/bin/g++ -DNDEBUG -DTEST_RESOURCES_DIR=\"/builddir/build/BUILD/giada-0.20.1/tests/resources/\" -DWITH_AUDIO_JACK -DWITH_TESTS -D__LINUX_ALSA__ -D__LINUX_PULSE__ -D__UNIX_JACK__ -I/builddir/build/BUILD/giada-0.20.1 -I/builddir/build/BUILD/giada-0.20.1/src -isystem /usr/include/rtmidi -isystem /usr/include/opus -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -Wall -Wextra -Wpedantic -pthread -D__UNIX_JACK__ -D__LINUX_ALSA__ -MD -MT CMakeFiles/giada.dir/src/gui/elems/basics/flex.cpp.o -MF CMakeFiles/giada.dir/src/gui/elems/basics/flex.cpp.o.d -o CMakeFiles/giada.dir/src/gui/elems/basics/flex.cpp.o -c /builddir/build/BUILD/giada-0.20.1/src/gui/elems/basics/flex.cpp
/builddir/build/BUILD/giada-0.20.1/src/gui/elems/basics/flex.cpp: In member function 'virtual void giada::v::geFlex::resize(int, int, int, int)':
/builddir/build/BUILD/giada-0.20.1/src/gui/elems/basics/flex.cpp:93:15: error: 'size_t' does not name a type
   93 |         const size_t numAllElems    = m_elems.size();
      |               ^~~~~~
/builddir/build/BUILD/giada-0.20.1/src/gui/elems/basics/flex.cpp:3:1: note: 'size_t' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
    2 | #include <numeric>
  +++ |+#include <cstddef>
    3 | 
/builddir/build/BUILD/giada-0.20.1/src/gui/elems/basics/flex.cpp:94:15: error: 'size_t' does not name a type
   94 |         const size_t numLiquidElems = numAllElems - m_numFixed;
      |               ^~~~~~
/builddir/build/BUILD/giada-0.20.1/src/gui/elems/basics/flex.cpp:94:15: note: 'size_t' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
/builddir/build/BUILD/giada-0.20.1/src/gui/elems/basics/flex.cpp:102:13: error: 'numLiquidElems' was not declared in this scope
  102 |         if (numLiquidElems == 0)
      |             ^~~~~~~~~~~~~~
/builddir/build/BUILD/giada-0.20.1/src/gui/elems/basics/flex.cpp:111:56: error: 'numAllElems' was not declared in this scope
  111 |         const int availableSize  = size - (m_gutter * (numAllElems - 1)); // Total size - gutters
      |                                                        ^~~~~~~~~~~
/builddir/build/BUILD/giada-0.20.1/src/gui/elems/basics/flex.cpp:112:71: error: 'numLiquidElems' was not declared in this scope
  112 |         const int liquidElemSize = (availableSize - fixedElemsSize) / numLiquidElems;
      |                                                                       ^~~~~~~~~~~~~~
```

This is very similar to the already-merged https://github.com/monocasual/giada/pull/554, which was for `<memory>` and `std::unique_ptr`.