### PR TITLE
Create .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,23 @@
+image: syso/giada-builder:latest
+
+stages:
+  - build
+
+build-job:
+  stage: build
+  variables:
+    GIT_SUBMODULE_STRATEGY: recursive
+  script:
+    - wget https://archive.org/download/VST2SDK/vst_sdk2_4_rev2.zip
+    - unzip vst_sdk2_4_rev2.zip
+    - mkdir src/deps/vst3sdk/plugininterfaces || exit 0
+    - cp -r vstsdk2.4/pluginterfaces/vst2.x/  src/deps/vst3sdk/pluginterfaces/
+    - cp -r vstsdk2.4/pluginterfaces/vst2.x  src/deps/vst3sdk/pluginterfaces/
+    - cmake -B build/ -S . -DWITH_VST3=ON -DWITH_VST2=ON -DCMAKE_BUILD_TYPE=Release -DRASPBERRYPI=ON -DWITH_PULSE=OFF -DWITH_ALSA=OFF
+    - cd build && make -j6
+  cache:
+    paths:
+      - build
+  artifacts:
+    paths:
+      - build/giada


### PR DESCRIPTION
This is partB of a revamped version of https://github.com/monocasual/giada/pull/504, that only includes the ".gitlab-ci.yml" changes.

this PR has squashed the various commits that change this file.

please note that there are some things i find a bit weird about this PR:
- this uses [syso/giada-builder](https://hub.docker.com/r/syso/giada-builder) as the Docker base image, rather than [monocasual/giada-docker](https://hub.docker.com/r/monocasual/giada-docker)
 - I don't know anything about the details, but the latter seems to be the more natural choice...
- it seems that *giada* is not using GitLab at all, so I see little point in having a CI-configuration for it.
  - I have rather strong feelings about git-providers encouraging people to leave their hoster-specific marks everywhere in the repository
  - GitLab at least offers the possibility, to add a URL as the CI-configuration, and you can do that in the project settings. so you don't really need to put that file into the repository itself (esp. if you don't use GitLab as the main provider)