### PR TITLE
Exclude repository configuration from tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# exclude repository configuration from tarball exports
+.git*      	export-ignore
+.travis.yml	export-ignore


### PR DESCRIPTION
This PR adds a `.gitattributes` file, that makes sure that no repository and CI configuration is exported in the source tarballs.

Including repository configuration (like `.gitignore` or `.gitmodules`) and CI-configs (like `.github/workflows/*` or `.gitlab-ci.yml`) into the automatically generated source-tarballs (e.g. what you get when you click on the [Source code (tar.gz)](https://github.com/monocasual/giada/archive/refs/tags/v0.20.1.tar.gz) link for a release) if often harmful for downstreams:
- they won't be able to use things like `.gitmodules`anyhow, as they only get a tarball without the git-repository
- it interacts badly if they import the release tarball into their own git-repository
  - this is really the thing that drives this PR. In Debian we are using *git* for tracking out packaging works. However, we (often) don't just work with a clone of the (your) upstream repository, but import release tarballs. We definitely do want to see build artifacts when doing a `git status` (to better track our cleanup process), so `.gitignore` is really harmful for our workflow. We also don't want to accidentally trigger our own CI with stray `.gitlab-ci.yml` files (we do have our CI, but that targets the packaging workflow)
- it just gives you nicer and cleaner source tarballs (there's really no use for anybody in having a github issue template in a hidden folder of your sources)

the PR also excludes a tentative `.travis.yml` file, just in case :-)