### PR TITLE
Remove duplicate Comment in desktop file

### DIFF
--- a/extras/com.giadamusic.Giada.desktop
+++ b/extras/com.giadamusic.Giada.desktop
@@ -3,7 +3,6 @@ Version=1.0
 Type=Application
 Name=Giada
 GenericName=Drum machine and loop sequencer
-Comment=Drum machine and loop sequencer
 GenericName[de]=Drum Maschine und Loop Sequenzer
 GenericName[es]=Caja de ritmos y secuenciador de loops
 GenericName[fr]=Boîte à rythme et séquenceur de boucle


### PR DESCRIPTION
This caused `desktop-file-validate` (from [desktop-file-utils](https://www.freedesktop.org/wiki/Software/desktop-file-utils/)) to fail.

Before:

```
$ desktop-file-validate extras/com.giadamusic.Giada.desktop 
extras/com.giadamusic.Giada.desktop: error: file contains multiple keys named "Comment" in group "Desktop Entry"
extras/com.giadamusic.Giada.desktop: warning: value "Drum machine and loop sequencer" for key "Comment" in group "Desktop Entry" looks the same as that of key "GenericName"
extras/com.giadamusic.Giada.desktop: warning: value "Drum machine and loop sequencer" for key "Comment" in group "Desktop Entry" looks the same as that of key "GenericName"
extras/com.giadamusic.Giada.desktop: warning: value "Drum Maschine und Loop Sequenzer" for key "Comment[de]" in group "Desktop Entry" looks the same as that of key "GenericName[de]"
extras/com.giadamusic.Giada.desktop: warning: value "Caja de ritmos y secuenciador de loops" for key "Comment[es]" in group "Desktop Entry" looks the same as that of key "GenericName[es]"
extras/com.giadamusic.Giada.desktop: warning: value "Boîte à rythme et séquenceur de boucle" for key "Comment[fr]" in group "Desktop Entry" looks the same as that of key "GenericName[fr]"
```

After:

```
$ desktop-file-validate extras/com.giadamusic.Giada.desktop 
extras/com.giadamusic.Giada.desktop: warning: value "Drum machine and loop sequencer" for key "Comment" in group "Desktop Entry" looks the same as that of key "GenericName"
extras/com.giadamusic.Giada.desktop: warning: value "Drum Maschine und Loop Sequenzer" for key "Comment[de]" in group "Desktop Entry" looks the same as that of key "GenericName[de]"
extras/com.giadamusic.Giada.desktop: warning: value "Caja de ritmos y secuenciador de loops" for key "Comment[es]" in group "Desktop Entry" looks the same as that of key "GenericName[es]"
extras/com.giadamusic.Giada.desktop: warning: value "Boîte à rythme et séquenceur de boucle" for key "Comment[fr]" in group "Desktop Entry" looks the same as that of key "GenericName[fr]"
```