### PR TITLE
Support external nlohmann_json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,7 @@ endif()
 option(WITH_VST2 "Enable VST2 support." OFF)
 option(WITH_VST3 "Enable VST3 support." OFF)
 option(WITH_TESTS "Include the test suite." OFF)
+option(WITH_SYSTEM_JSON "Use a system copy of nlohmann_json." OFF)
 
 if(DEFINED OS_LINUX)
 	option(WITH_ALSA "Enable ALSA support (Linux only)." ON)
@@ -397,9 +398,18 @@ list(APPEND LIBRARIES fmt::fmt)
 
 # nlohmann_json (embedded as git submodule)
 
-set(JSON_Install OFF CACHE INTERNAL "") # No need to install it
-set(JSON_BuildTests OFF CACHE INTERNAL "") # Don't build tests
-add_subdirectory(src/deps/json)
+if (WITH_SYSTEM_JSON)
+
+	find_package(nlohmann_json REQUIRED)
+
+else()
+
+	set(JSON_Install OFF CACHE INTERNAL "") # No need to install it
+	set(JSON_BuildTests OFF CACHE INTERNAL "") # Don't build tests
+	add_subdirectory(src/deps/json)
+
+endif()
+
 list(APPEND LIBRARIES nlohmann_json::nlohmann_json)
 
 # Catch (if tests enabled)


### PR DESCRIPTION
Add a CMake option `WITH_SYSTEM_JSON`, disabled by default.

This PR would not change the default behavior, but it would make using the system `nlohmann_json` as easy as setting the CMake option.

-----

As maintainer of the Fedora Linux `giada` package, the new and improved handling of the `nlohmann_json` library in `CMakeLists.txt` in version 0.22.0 makes it harder for me to build with a system copy of the library, since I have to patch `CMakeLists.txt`.

https://github.com/monocasual/giada/blob/96cfc398c8d0dd5d172ac9b3d233ee9f89f7effe/CMakeLists.txt#L400-L403

On the other hand, I no longer have to patch the `#include` paths in a bunch of source files, since they no longer include a `deps/json/single_include/` prefix, which is great by itself, and also necessary for the approach in this PR to work.

https://github.com/monocasual/giada/blob/96cfc398c8d0dd5d172ac9b3d233ee9f89f7effe/src/core/conf.cpp#L35