### PR TITLE
Fix build with fmt 9, GCC 12

### DIFF
--- a/src/gui/dialogs/about.cpp
+++ b/src/gui/dialogs/about.cpp
@@ -62,7 +62,7 @@ gdAbout::gdAbout()
 
 			geBox* text = new geBox();
 			text->align(FL_ALIGN_CENTER | FL_ALIGN_INSIDE | FL_ALIGN_TOP);
-			text->copy_label(fmt::format(g_ui.getI18Text(LangMap::ABOUT_BODY),
+			text->copy_label(fmt::format(fmt::runtime(g_ui.getI18Text(LangMap::ABOUT_BODY)),
 			    G_VERSION_STR, debug ? "Debug" : "Release", BUILD_DATE)
 			                     .c_str());
 

--- a/src/gui/dialogs/sampleEditor.cpp
+++ b/src/gui/dialogs/sampleEditor.cpp
@@ -228,7 +228,7 @@ void gdSampleEditor::refresh()
 
 void gdSampleEditor::updateInfo()
 {
-	std::string infoText = fmt::format(g_ui.getI18Text(LangMap::SAMPLEEDITOR_INFO),
+	std::string infoText = fmt::format(fmt::runtime(g_ui.getI18Text(LangMap::SAMPLEEDITOR_INFO)),
 	    m_data.wavePath, m_data.waveSize, m_data.waveDuration,
 	    m_data.waveBits != 0 ? std::to_string(m_data.waveBits) : "?", m_data.waveRate);
 

--- a/src/gui/elems/config/tabPlugins.cpp
+++ b/src/gui/elems/config/tabPlugins.cpp
@@ -89,7 +89,7 @@ geTabPlugins::geTabPlugins(geompp::Rect<int> bounds)
 
 	m_scanButton->onClick = [this]() {
 		std::function<void(float)> callback = [this](float progress) {
-			std::string l = fmt::format(g_ui.getI18Text(LangMap::CONFIG_PLUGINS_SCANNING), static_cast<int>(progress * 100));
+			std::string l = fmt::format(fmt::runtime(g_ui.getI18Text(LangMap::CONFIG_PLUGINS_SCANNING)), static_cast<int>(progress * 100));
 			m_info->label(l.c_str());
 			Fl::wait();
 		};
@@ -109,7 +109,7 @@ void geTabPlugins::rebuild()
 {
 	m_data = c::config::getPluginData();
 
-	const std::string scanLabel = fmt::format(g_ui.getI18Text(LangMap::CONFIG_PLUGINS_SCAN), m_data.numAvailablePlugins);
+	const std::string scanLabel = fmt::format(fmt::runtime(g_ui.getI18Text(LangMap::CONFIG_PLUGINS_SCAN)), m_data.numAvailablePlugins);
 	m_scanButton->copy_label(scanLabel.c_str());
 
 	m_folderPath->setValue(m_data.pluginPath);


### PR DESCRIPTION
fmt::format requires the non-static format argument to be wrapped with fmt::runtime check.

Fixes #634