### PR TITLE
Fix build (gentoo gcc-11 and clang-15 fail with same error)

### DIFF
--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -67,9 +67,9 @@ static void print(const char* format, Args&&... args)
 	if (mode == LOG_MODE_MUTE)
 		return;
 	if (mode == LOG_MODE_FILE && file.is_open())
-		fmt::print(file, format, args...);
+		fmt::print(file, fmt::runtime(format), args...);
 	else
-		fmt::print(format, args...);
+		fmt::print(fmt::runtime(format), args...);
 }
 } // namespace giada::u::log
 


### PR DESCRIPTION
```
[  4%] Building CXX object CMakeFiles/giada.dir/src/core/engine.cpp.o
In file included from /home/nedko/git/giada/src/core/engine.cpp:32:
/home/nedko/git/giada/src/utils/log.h:70:20: error: call to consteval function 'fmt::basic_format_string<char>::basic_format_string<const char *, 0>' is not a constant expression
                fmt::print(file, format, args...);
                                 ^
/home/nedko/git/giada/src/core/engine.cpp:263:11: note: in instantiation of function template specialization 'giada::u::log::print<>' requested here
                u::log::print("[Engine::shutdown] KernelAudio closed\n");
                        ^
/usr/include/fmt/core.h:3148:67: note: function parameter 'format' with unknown value cannot be used in a constant expression
  FMT_CONSTEVAL FMT_INLINE basic_format_string(const S& s) : str_(s) {
                                                                  ^
/home/nedko/git/giada/src/utils/log.h:70:20: note: in call to 'basic_format_string(format)'
                fmt::print(file, format, args...);
                                 ^
/home/nedko/git/giada/src/utils/log.h:65:31: note: declared here
static void print(const char* format, Args&&... args)
                              ^
/home/nedko/git/giada/src/utils/log.h:72:14: error: call to consteval function 'fmt::basic_format_string<char>::basic_format_string<const char *, 0>' is not a constant expression
                fmt::print(format, args...);
                           ^
/usr/include/fmt/core.h:3148:67: note: function parameter 'format' with unknown value cannot be used in a constant expression
  FMT_CONSTEVAL FMT_INLINE basic_format_string(const S& s) : str_(s) {
                                                                  ^
/home/nedko/git/giada/src/utils/log.h:72:14: note: in call to 'basic_format_string(format)'
                fmt::print(format, args...);
                           ^
/home/nedko/git/giada/src/utils/log.h:65:31: note: declared here
static void print(const char* format, Args&&... args)
                              ^
/home/nedko/git/giada/src/utils/log.h:70:20: error: call to consteval function 'fmt::basic_format_string<char, std::basic_string<char> &>::basic_format_string<const char *, 0>' is not a constant expression
                fmt::print(file, format, args...);
                                 ^
/home/nedko/git/giada/src/core/engine.cpp:365:11: note: in instantiation of function template specialization 'giada::u::log::print<std::basic_string<char>>' requested here
                u::log::print("[Engine::registerThread] Can't register thread {}! Aborting\n", u::string::toString(t));
                        ^
/usr/include/fmt/core.h:3148:67: note: function parameter 'format' with unknown value cannot be used in a constant expression
  FMT_CONSTEVAL FMT_INLINE basic_format_string(const S& s) : str_(s) {
                                                                  ^
/home/nedko/git/giada/src/utils/log.h:70:20: note: in call to 'basic_format_string(format)'
                fmt::print(file, format, args...);
                                 ^
/home/nedko/git/giada/src/utils/log.h:65:31: note: declared here
static void print(const char* format, Args&&... args)
                              ^
/home/nedko/git/giada/src/utils/log.h:72:14: error: call to consteval function 'fmt::basic_format_string<char, std::basic_string<char> &>::basic_format_string<const char *, 0>' is not a constant expression
                fmt::print(format, args...);
                           ^
/usr/include/fmt/core.h:3148:67: note: function parameter 'format' with unknown value cannot be used in a constant expression
  FMT_CONSTEVAL FMT_INLINE basic_format_string(const S& s) : str_(s) {
                                                                  ^
/home/nedko/git/giada/src/utils/log.h:72:14: note: in call to 'basic_format_string(format)'
                fmt::print(format, args...);
                           ^
/home/nedko/git/giada/src/utils/log.h:65:31: note: declared here
static void print(const char* format, Args&&... args)
                              ^
4 errors generated.
gmake[2]: *** [CMakeFiles/giada.dir/build.make:104: CMakeFiles/giada.dir/src/core/engine.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:176: CMakeFiles/giada.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2

```

Downstream issue: https://github.com/LADI/giada/issues/1