### PR TITLE
Include <cstdint> for uint32_t

### DIFF
--- a/src/core/const.h
+++ b/src/core/const.h
@@ -29,6 +29,7 @@
 
 #include "deps/rtaudio/RtAudio.h"
 #include <RtMidi.h>
+#include <cstdint>
 
 /* -- environment ----------------------------------------------------------- */
 #if defined(_WIN32)

--- a/src/gui/elems/midiIO/midiLearner.h
+++ b/src/gui/elems/midiIO/midiLearner.h
@@ -30,6 +30,7 @@
 #include "gui/elems/basics/flex.h"
 #include <functional>
 #include <string>
+#include <cstdint>
 
 namespace giada::v
 {


### PR DESCRIPTION
gcc-13 is a bit more strict when it comes to missing includes, resulting in FTBFS.

afaict, the github actions run on Ubuntu 20.04, which uses some rather dated compiler (gcc-10.3.0)
https://github.com/monocasual/giada/actions/runs/5662005386/job/15341078194#step:4:342
which explains why it doesn't catch build errors with newer compilers.