### PR TITLE
Fix plugin browser empty crash

### DIFF
--- a/src/gui/elems/plugin/pluginBrowser.cpp
+++ b/src/gui/elems/plugin/pluginBrowser.cpp
@@ -31,6 +31,7 @@
 #include "src/gui/ui.h"
 #include "src/utils/gui.h"
 #include <fmt/core.h>
+#include <iterator>
 
 extern giada::v::Ui* g_ui;
 
@@ -144,6 +145,9 @@ void gePluginBrowser::prepareLayout()
 
 int gePluginBrowser::getContentWidth(int row, int column) const
 {
+	if (m_pluginInfo.empty())
+		return G_GUI_UNIT * 10;
+
 	const auto columnToField = [this](int row, int column) -> const std::string&
 	{
 		switch (static_cast<Column>(column))

--- a/src/gui/elems/plugin/pluginBrowser.cpp
+++ b/src/gui/elems/plugin/pluginBrowser.cpp
@@ -31,7 +31,6 @@
 #include "src/gui/ui.h"
 #include "src/utils/gui.h"
 #include <fmt/core.h>
-#include <iterator>
 
 extern giada::v::Ui* g_ui;
 


### PR DESCRIPTION
I've added a line of code that stops the program crashing when the plugin info hasn't been populated. This seems to be the default setup when the settings for the plugin directory has been left blank? It just returns a default value and allows an empty window to open rather than crashing.